### PR TITLE
Fixes #261

### DIFF
--- a/archive-map-layer.php
+++ b/archive-map-layer.php
@@ -40,7 +40,10 @@
 						elseif ($count_num % 4 == 1):
 								echo "<div class='grid-row'>";
 						endif;
-						odm_get_template('post-grid-single-4-cols-caption-below',array( "post" => $layer, "show_meta" => false), true);
+						odm_get_template('post-grid-single-4-cols',array(
+              "post" => $layer, 
+              "show_meta" => false)
+            , true);
 						if($count_num % 4 == 0 || $count_num == $pagination["end_post"]) :
 							echo "</div>";
 						endif;

--- a/archive-map-layer.php
+++ b/archive-map-layer.php
@@ -33,25 +33,10 @@
 				//Pagination
 				$pagination = get_pagination_of_layers_grouped_by_subcategory($map_catalogue);
 				foreach ($map_catalogue as $key => $layer) {
-					$count_num = $key + 1;  //Count Item start from 1
-					if($count_num >= $pagination["start_post"] && $count_num <= $pagination["end_post"] ):
-						if($count_num == $pagination["start_post"]):
-							echo "<div class='grid-row'>";
-						elseif ($count_num % 4 == 1):
-								echo "<div class='grid-row'>";
-						endif;
-						odm_get_template('post-grid-single-4-cols',array(
-              "post" => $layer, 
-              "show_meta" => false)
-            , true);
-						if($count_num % 4 == 0 || $count_num == $pagination["end_post"]) :
-							echo "</div>";
-						endif;
-
-						if($count_num == $pagination["end_post"]):
-							 break;
-						endif;
-					endif;
+					odm_get_template('post-grid-single-4-cols',array(
+            "post" => $layer,
+            "show_meta" => false)
+          , true);
 				}
 			?>
       </div>

--- a/inc/mapping.php
+++ b/inc/mapping.php
@@ -387,7 +387,7 @@ function get_selected_layers_of_map_by_mapID($map_ID) {
 		$map_ID = get_the_ID();
 	}
 
-	$get_basemap = get_post_meta($map_ID, 'map_data', true); 
+	$get_basemap = get_post_meta($map_ID, 'map_data', true);
 	if(!empty($get_basemap)){
 		if($get_basemap['base_layer']) {
 				$base_map = array(
@@ -481,13 +481,13 @@ function get_layer_information_in_array($post_ID){
 	endif;
 	*/
 
-	$title_and_link = "<a class='item-title' target='_blank' href='".get_site_url()."/dataset/?id=".$get_ckan_dataset_id[1]."'>". get_the_title() . "</a>";
 	$download_link = get_site_url()."/dataset/?id=".$get_ckan_dataset_id[1];
 	//get category of post by post_id
 	$layer_cat = wp_get_post_terms($post_ID, 'layer-category',  array("fields" => "all"));
 	$layer = (object) array("ID" => get_the_ID(),
 								"post_title" => get_the_title(),
 								"download_link" => $download_link,
+								"dataset_link" => get_site_url()."/dataset/?id=".$get_ckan_dataset_id[1],
 								"title_and_link" => $title_and_link,
 								//"thumbnail_link" => $thumbnail_url,
 								//"description" => get_the_content(),

--- a/inc/templates/post-grid-single-1-cols.php
+++ b/inc/templates/post-grid-single-1-cols.php
@@ -16,7 +16,9 @@
 		<a class="item-post-type" href="<?php echo $post_type->rewrite['slug'] ?>"><?php echo $post_type->labels->name ?></a>
 		<?php
 			endif; ?>
-		<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
+    <?php
+      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
+		<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
 		<?php if ($show_meta): ?>
 		<div class="meta">
 				<?php echo_post_meta($post,array('date','sources','categories')); ?>

--- a/inc/templates/post-grid-single-2-cols.php
+++ b/inc/templates/post-grid-single-2-cols.php
@@ -16,7 +16,9 @@
 		<a class="item-post-type" href="<?php echo $post_type->rewrite['slug'] ?>"><?php echo $post_type->labels->name ?></a>
 		<?php
 			endif; ?>
-		<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
+    <?php
+      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
+		<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
 		<?php if ($show_meta): ?>
 		<div class="meta">
 				<?php echo_post_meta($post,array('date','sources','categories')); ?>

--- a/inc/templates/post-grid-single-4-cols-caption-below.php
+++ b/inc/templates/post-grid-single-4-cols-caption-below.php
@@ -20,22 +20,16 @@
 			endif;
 		?>
 
-		<?php
-		if (isset($post->title_and_link) && $post->title_and_link != "") :
-			echo $post->title_and_link;
-		else:
-			?>
-			<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
+    <?php
+      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
+		<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
 			<?php
-		endif;
-		?>
-		<?php /*
 		if (isset($post->description) && $post->description != "") :?>
 			<div class="post-grid-item-list">
 					<?php echo $post->description;   ?>
 			</div>
 			<?php
-		endif;*/
+		endif;
 		?>
 	</div>
 </div>

--- a/inc/templates/post-grid-single-4-cols.php
+++ b/inc/templates/post-grid-single-4-cols.php
@@ -16,7 +16,9 @@
 		<a class="item-post-type" href="<?php echo $post_type->rewrite['slug'] ?>"><?php echo $post_type->labels->name ?></a>
 		<?php
 			endif; ?>
-		<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
+    <?php 
+      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
+		<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>"><?php echo $post->post_title; ?></a>
 		<?php if ($show_meta): ?>
 		<div class="meta">
 				<?php echo_post_meta($post,array('date','sources','categories')); ?>

--- a/inc/templates/post-list-single-1-cols.php
+++ b/inc/templates/post-list-single-1-cols.php
@@ -12,8 +12,10 @@
 <div class="sixteen columns">
 	<div class="post-list-item">
 		<?php if ($header_tag): ?>
+      <?php
+        $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
 			<h3>
-				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>">
+				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>">
 					<?php echo $post->post_title; ?>
 				</a>
 			</h3>

--- a/inc/templates/post-list-single-2-cols.php
+++ b/inc/templates/post-list-single-2-cols.php
@@ -12,8 +12,10 @@
 <div class="eight columns ">
 	<div class="post-list-item">
 		<?php if ($header_tag): ?>
+      <?php
+        $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
 			<h3>
-				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>">
+				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>">
 					<?php echo $post->post_title; ?>
 				</a>
 			</h3>

--- a/inc/templates/post-list-single-4-cols.php
+++ b/inc/templates/post-list-single-4-cols.php
@@ -12,8 +12,10 @@
 <div class="four columns ">
 	<div class="post-list-item">
 		<?php if ($header_tag): ?>
+      <?php
+        $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID); ?>
 			<h3>
-				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $post->post_title; ?>">
+				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $post->post_title; ?>">
 					<?php echo $post->post_title; ?>
 				</a>
 			</h3>


### PR DESCRIPTION
@Huyeng I believe we need to bring consistency in the visual elements that we use. That is why I have modified the code on the **map catalogue** in order to use the **post-grid-single-4-cols**. The previous layout was good but visually incoherent. We should be looking at ways of improving the current _grid boxes_ so they are more usable... let's have some thoughs together about that.

![screenshot from 2016-08-24 15-49-05](https://cloud.githubusercontent.com/assets/384894/17932980/9b060806-6a12-11e6-8855-f2adc157e21f.png)

Also, I have modified your logic on **mapping.php** file to include a _dataset_link_ attribute in order to replace the permalink on the post (in this case the map layers) with the link to the dataset. Basically, the same functionality as you had but more modular.