### PR TITLE
fixed font size of the image caption and reference number issue #421

### DIFF
--- a/less/_posts.less
+++ b/less/_posts.less
@@ -272,5 +272,10 @@
 		iframe {
 			max-width:100%;
 		}
+		p {
+			sub {
+				font-size: @font-size-h6;
+			}
+		}
 	}
 }

--- a/less/opendev.less
+++ b/less/opendev.less
@@ -76,11 +76,14 @@ td{
 }
 
 .wp-caption-text {
-    font-size: 17px;
+    font-size: @font-size-h5;
     line-height: 24px;
     color: #777;
     font-style: italic;
     clear: both;
+    a {
+      font-size: @font-size-h5;
+    }
 }
 
 .map-sidebar a {


### PR DESCRIPTION
This commit also fixes another minor error the sup-letter whose side is as big as normal letters.
![screenshot 1](https://cloud.githubusercontent.com/assets/18528756/18582998/4500be06-7c32-11e6-8ca3-e6491e20b773.png)
