### PR TITLE
Fixes #438

### DIFF
--- a/less/_layout.less
+++ b/less/_layout.less
@@ -327,7 +327,7 @@ body{
 
   li{
     list-style-type: none;
-    display: inline-block;
+    display: inline;
     margin-bottom: 0px;
   }
 


### PR DESCRIPTION
Currently:

![screenshot from 2016-09-21 21-24-03](https://cloud.githubusercontent.com/assets/384894/18725757/d231783e-8041-11e6-88db-77d3408e1794.png)

If we set https://github.com/OpenDevelopmentMekong/wp-odm_theme/blob/master/less/_layout.less#L330 to ```display: inline;``` then we get:

![screenshot from 2016-09-21 21-24-17](https://cloud.githubusercontent.com/assets/384894/18725848/3542cee6-8042-11e6-8cf5-e55786886587.png)
