### PR TITLE
Fixes #618

### DIFF
--- a/inc/country-manager.php
+++ b/inc/country-manager.php
@@ -33,6 +33,11 @@ class Odm_Country_Manager {
     return $current_country;
   }
 
+	function get_current_country_code(){
+    $current_country = $this->get_current_country();
+		return $this->countries[$current_country]['code'];
+  }
+
   function get_country_themes(){
     return [
       'Mekong' => 'mekong',

--- a/page-data.php
+++ b/page-data.php
@@ -149,28 +149,20 @@ Template Name: Data
 
       </form>
 
-      <?php
-        if (!$active_filters):
-          $shortcode = '[wpckan_number_of_query_datasets limit="1"';
-          if (isset($param_country) && $param_country != 'mekong'):
-            $shortcode .= ' filter_fields=\'{"extras_odm_spatial_range":"'. $countries[$param_country]['iso2'] . '"}\'';
-          endif;
-          ?>
-          <div class="sixteen columns">
-            <div class="data-number-results-small">
-              <p>
-                <p class="label"><label><?php _e('Current statistics: ','odm'); ?></label></p>
-                <?php echo do_shortcode($shortcode . ' type="dataset" suffix=" Datasets"]'); ?>
-                <?php echo do_shortcode($shortcode . ' type="library_record" suffix=" Library records"]'); ?>
-                <?php echo do_shortcode($shortcode . ' type="laws_record" suffix=" Laws"]'); ?>
-              </p>
-            </div>
-          </div>
-          <?php
-        endif; ?>
-
     </div>
   </div>
+
+  <?php
+    if (!$active_filters && function_exists('wpdash_get_ckan_stats_dataviz')): ?>
+      <div class="container">
+        <div class="row">
+          <div class="eight columns">
+            <?php wpdash_get_ckan_stats_dataviz(); ?>
+          </div>
+        </div>
+      </div>
+  <?php
+    endif; ?>
 
   <section class="container">
     <div class="row">

--- a/page-data.php
+++ b/page-data.php
@@ -153,11 +153,14 @@ Template Name: Data
   </div>
 
   <?php
-    if (!$active_filters && function_exists('wpdash_get_ckan_stats_dataviz')): ?>
+    if (!$active_filters && function_exists('wpdash_get_ckan_stats_dataviz_by_type') && function_exists('wpdash_get_ckan_stats_dataviz_by_taxonomy')): ?>
       <div class="container">
         <div class="row">
-          <div class="eight columns">
-            <?php wpdash_get_ckan_stats_dataviz(); ?>
+          <div class="four columns">
+            <?php wpdash_get_ckan_stats_dataviz_by_type(); ?>
+          </div>
+          <div class="twelve columns">
+            <?php wpdash_get_ckan_stats_dataviz_by_taxonomy(); ?>
           </div>
         </div>
       </div>

--- a/page-data.php
+++ b/page-data.php
@@ -160,7 +160,7 @@ Template Name: Data
             <?php wpdash_get_ckan_stats_dataviz_by_type(); ?>
           </div>
           <div class="twelve columns">
-            <?php wpdash_get_ckan_stats_dataviz_by_taxonomy(); ?>
+            <?php wpdash_get_ckan_stats_dataviz_by_taxonomy(null); ?>
           </div>
         </div>
       </div>


### PR DESCRIPTION
@Huyeng @prustar @DragonVirus  This PR (and its counterpart on wp-odm_dash https://github.com/OpenDevelopmentMekong/wp-odm_dash/pull/56 adds 2 datavizs on the data page which represent:

- the number of records by type
- the number of records by the main taxonomic terms

It currently looks like this:
![screenshot from 2016-11-24 12-29-13](https://cloud.githubusercontent.com/assets/384894/20597013/a4efd79e-b241-11e6-9289-2aa1af01f727.png)

And also, similar datavizs on the Laws pages (see its counterpart on wp-odm_tabular https://github.com/OpenDevelopmentMekong/wp-odm_tabular_pages/pull/30 ):

- the number of records by language
- the number of records by the main taxonomic terms

It currently looks like this:
![screenshot from 2016-11-24 14-53-51](https://cloud.githubusercontent.com/assets/384894/20600956/69e4bd62-b256-11e6-8d20-f281216a85db.png)


The current functionality **ONLY** exposes the information when the users go to the Data page and as long as no other filter was applied ( by language, type, etc..). This implementation could be improved in folowing ways (just ideas):

- Adapt the colours to match those of the current country site  
- Add interactivity so when the user clicks on one column, it is taken to the corresponding list of filtered results
- Other statistics could be added as well ( number of datasets by language, etc...)
- Add animations to display the chart once the data has loaded
- Change the logic so data is pulled asynchronously, which would improve the performance of the code considerably.

**NOTE**: This has not being deployed to PP yet. I can demo it for you if you want to have a better sense on how this works. I will wait for your feedback in order to discuss and implement any suggestions you might have. Then, after being deployed and tested on PP, we can include it in the rollout of the code for 2.1.0 planned for the 5th of december.
