### PR TITLE
Fixes #397

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -11,17 +11,17 @@ get_header();
 		<div class="sixteen columns">
 			<h1 class="archive-title"><?php
 					if( is_tag() || is_category() || is_tax() ) :
-						printf( __( '%s', 'jeo' ), single_term_title() );
+						printf( __( '%s', 'odm' ), single_term_title() );
 					elseif ( is_day() ) :
-						printf( __( 'Daily Archives: %s', 'jeo' ), get_the_date() );
+						printf( __( 'Daily Archives: %s', 'odm' ), get_the_date() );
 					elseif ( is_month() ) :
-						printf( __( 'Monthly Archives: %s', 'jeo' ), get_the_date( _x( 'F Y', 'monthly archives date format', 'jeo' ) ) );
+						printf( __( 'Monthly Archives: %s', 'odm' ), get_the_date( _x( 'F Y', 'monthly archives date format', 'odm' ) ) );
 					elseif ( is_year() ) :
-						printf( __( 'Yearly Archives: %s', 'jeo' ), get_the_date( _x( 'Y', 'yearly archives date format', 'jeo' ) ) );
+						printf( __( 'Yearly Archives: %s', 'odm' ), get_the_date( _x( 'Y', 'yearly archives date format', 'odm' ) ) );
 					elseif ( is_post_type_archive() ) :
 						_e(post_type_archive_title('', 0));
 					else :
-						_e( 'Archives', 'jeo' );
+						_e( 'Archives', 'odm' );
 					endif;
 				?></h1>
 		</div>

--- a/content-embed.php
+++ b/content-embed.php
@@ -13,7 +13,7 @@
 		echo " | $site_description";
 
 	if ( $paged >= 2 || $page >= 2 )
-		echo ' | ' . __('Page', 'jeo') . max($paged, $page);
+		echo ' | ' . __('Page', 'odm') . max($paged, $page);
 
 	?></title>
 <link rel="profile" href="http://gmpg.org/xfn/11" />

--- a/content-map-group.php
+++ b/content-map-group.php
@@ -24,7 +24,7 @@ foreach($mapgroup['maps'] as $map) {
 				endforeach; ?>
 				<?php if($more_maps) : ?>
 					<li class="more-tab">
-						<a href="#" class="toggle-more"><?php _e('More...', 'jeo'); ?></a>
+						<a href="#" class="toggle-more"><?php _e('More...', 'odm'); ?></a>
 						<ul class="more-maps-list">
 							<?php foreach($more_maps as $map) :
 								$post = get_post($map['id']);
@@ -34,7 +34,7 @@ foreach($mapgroup['maps'] as $map) {
 								<?php
 								wp_reset_postdata();
 							endforeach; ?>
-							<li><a href="<?php echo qtrans_convertURL(get_post_type_archive_link('map')); ?>"><?php _e('View all maps', 'jeo'); ?></a></li>
+							<li><a href="<?php echo qtrans_convertURL(get_post_type_archive_link('map')); ?>"><?php _e('View all maps', 'odm'); ?></a></li>
 						</ul>
 					</li>
 				<?php endif; ?>

--- a/footer.php
+++ b/footer.php
@@ -35,7 +35,7 @@
   			</nav>
   		</div>
       <div class="four columns">
-  			<p><?php printf(__('This website is built on <a href="%s" target="_blank" rel="external">WordPress</a> using the <a href="%s" target="_blank" rel="external">JEO Beta</a> theme', 'jeo'), 'http://wordpress.org', 'https://github.com/oeco/jeo'); ?></p>
+  			<p><?php printf(__('This website is built on <a href="%s" target="_blank" rel="external">WordPress</a> using the <a href="%s" target="_blank" rel="external">JEO Beta</a> theme', 'odm'), 'http://wordpress.org', 'https://github.com/oeco/jeo'); ?></p>
   		</div>
 			<?php
 		  if(odm_country_manager()->get_current_country() != "cambodia"): ?>

--- a/functions.php
+++ b/functions.php
@@ -41,22 +41,21 @@ require_once get_stylesheet_directory().'/inc/utils/urls.php';
 require_once get_stylesheet_directory().'/inc/utils/config.php';
 
 /*
- * Loads the theme's translated strings. for 'odm' and 'jeo' domains
+ * Loads the theme's translated strings. for 'odm' domains
  * Registers widget sidebars
  */
 function odm_setup_theme()
 {
     $gsd = explode('wp-content', get_stylesheet_directory());
     load_theme_textdomain('odm', $gsd[0].'/wp-content/languages');
-    load_theme_textdomain('jeo', $gsd[0].'/wp-content/languages');
     register_sidebar(array(
-    'name' => __('Topic sidebar', 'jeo'),
+    'name' => __('Topic sidebar', 'odm'),
     'id' => 'topic',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
   ));
     register_sidebar(array(
-    'name' => __('Homepage area top left', 'jeo'),
+    'name' => __('Homepage area top left', 'odm'),
     'id' => 'homepage-area-1',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
@@ -64,7 +63,7 @@ function odm_setup_theme()
 	  'after_widget'  => ''
   ));
     register_sidebar(array(
-    'name' => __('Homepage area top right', 'jeo'),
+    'name' => __('Homepage area top right', 'odm'),
     'id' => 'homepage-area-2',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
@@ -72,7 +71,7 @@ function odm_setup_theme()
     'after_widget'  => ''
   ));
     register_sidebar(array(
-    'name' => __('Homepage area middle', 'jeo'),
+    'name' => __('Homepage area middle', 'odm'),
     'id' => 'homepage-area-3',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
@@ -80,7 +79,7 @@ function odm_setup_theme()
     'after_widget'  => ''
   ));
     register_sidebar(array(
-    'name' => __('Homepage area bottom left', 'jeo'),
+    'name' => __('Homepage area bottom left', 'odm'),
     'id' => 'homepage-area-4',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
@@ -88,7 +87,7 @@ function odm_setup_theme()
 	  'after_widget'  => ''
   ));
     register_sidebar(array(
-    'name' => __('Homepage area bottom right', 'jeo'),
+    'name' => __('Homepage area bottom right', 'odm'),
     'id' => 'homepage-area-5',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
@@ -96,19 +95,19 @@ function odm_setup_theme()
 	  'after_widget'  => ''
   ));
     register_sidebar(array(
-    'name' => __('WPCKAN Dataset detail sidebar', 'jeo'),
+    'name' => __('WPCKAN Dataset detail sidebar', 'odm'),
     'id' => 'wpckan-dataset-detail-sidebar',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
   ));
     register_sidebar(array(
-    'name' => __('Story top', 'jeo'),
+    'name' => __('Story top', 'odm'),
     'id' => 'story-top',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
   ));
     register_sidebar(array(
-    'name' => __('Story bottom', 'jeo'),
+    'name' => __('Story bottom', 'odm'),
     'id' => 'story-bottom',
     'before_title' => '<h2 class="widget-title">',
     'after_title' => '</h2>',
@@ -258,7 +257,7 @@ function odm_jeo_scripts()
 
     wp_localize_script('jeo-share-widget', 'extended_jeo_share_widget_settings', array(
     	'baseurl' => extended_jeo_get_embed_url(),
-    	'default_label' => __('default', 'jeo')
+    	'default_label' => __('default', 'odm')
     ));
   }
 

--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@
     }
 
     if ($paged >= 2 || $page >= 2) {
-        echo ' | '.__('Page', 'jeo').max($paged, $page);
+        echo ' | '.__('Page', 'odm').max($paged, $page);
     } ?>
 
 </title>

--- a/inc/layer-category.php
+++ b/inc/layer-category.php
@@ -15,7 +15,7 @@ class OpenDev_Map_Category {
 	}
 
 	function admin_menu() {
-		add_submenu_page('edit.php?post_type=map', __('Layer categories', 'jeo'), __('Layer categories', 'jeo'), 'edit_posts', 'edit-tags.php?taxonomy=layer-category');
+		add_submenu_page('edit.php?post_type=map', __('Layer categories', 'odm'), __('Layer categories', 'odm'), 'edit_posts', 'edit-tags.php?taxonomy=layer-category');
 	}
 
 	function register_taxonomy() {

--- a/inc/layers.php
+++ b/inc/layers.php
@@ -21,7 +21,7 @@
         // Layer settings
         add_meta_box(
             'layer-settings',
-            __('Layer settings', 'jeo'),
+            __('Layer settings', 'odm'),
             array($this, 'settings_box'),
             'map-layer',
             'advanced',
@@ -30,7 +30,7 @@
         // Layer legend
         add_meta_box(
             'layer-legend',
-            __('Layer legend', 'jeo'),
+            __('Layer legend', 'odm'),
             array($this, 'legend_box'),
             'map-layer',
             'side',
@@ -39,7 +39,7 @@
         // Post layers
         add_meta_box(
             'post-layers',
-            __('Layers', 'jeo'),
+            __('Layers', 'odm'),
             array($this, 'post_layers_box'),
             $this->add_layers_box_to_post_types(),
             'advanced',
@@ -52,10 +52,10 @@
         $legend_localization = $post ? get_post_meta($post->ID, '_layer_legend_localization', true) : '';
 
         ?>
-        <h4><?php _e('Enter your HTML code to use as legend on the layer (English)', 'jeo'); ?></h4>
+        <h4><?php _e('Enter your HTML code to use as legend on the layer (English)', 'odm'); ?></h4>
         <textarea name="_layer_legend" style="width:100%;height: 200px;"><?php echo $legend; ?></textarea>
         <?php if(odm_language_manager()->get_the_language_by_site()){ ?>
-              <h4><?php _e('Enter your HTML code to use as legend on the layer ('.odm_language_manager()->get_the_language_by_site().')', 'jeo'); ?></h4>
+              <h4><?php _e('Enter your HTML code to use as legend on the layer ('.odm_language_manager()->get_the_language_by_site().')', 'odm'); ?></h4>
               <textarea name="_layer_legend_localization" style="width:100%;height: 200px;"><?php echo $legend_localization; ?></textarea>
         <?php
             }
@@ -69,7 +69,7 @@
 
      <p>
       <?php
-      printf(__('Add and manage <a href="%s" target="_blank">layers</a> on your map.', 'jeo'), admin_url('edit.php?post_type=map-layer'));
+      printf(__('Add and manage <a href="%s" target="_blank">layers</a> on your map.', 'odm'), admin_url('edit.php?post_type=map-layer'));
       if(!$layer_query->have_posts())
        printf(__(' You haven\'t created any layers yet, <a href="%s" target="_blank">click here</a> to create your first!'), admin_url('post-new.php?post_type=map-layer'));
       ?>
@@ -83,22 +83,22 @@
        wp_reset_postdata();
       }
       ?>
-      <input type="text" data-bind="textInput: search" placeholder="<?php _e('Search for layers', 'jeo'); ?>" size="50">
+      <input type="text" data-bind="textInput: search" placeholder="<?php _e('Search for layers', 'odm'); ?>" size="50">
 
       <!-- ko if: !search() -->
-       <h4 class="results-title"><?php _e('Latest layers', 'jeo'); ?></h4>
+       <h4 class="results-title"><?php _e('Latest layers', 'odm'); ?></h4>
       <!-- /ko -->
 
       <!-- ko if: search() -->
-       <h4 class="results-title"><?php _e('Search results', 'jeo'); ?></h4>
+       <h4 class="results-title"><?php _e('Search results', 'odm'); ?></h4>
       <!-- /ko -->
 
       <!-- ko if: !filteredLayers().length && !search() -->
-       <p style="font-style:italic;color: #999;"><?php _e('You are using all of your layers.', 'jeo'); ?></p>
+       <p style="font-style:italic;color: #999;"><?php _e('You are using all of your layers.', 'odm'); ?></p>
       <!-- /ko -->
 
       <!-- ko if: !filteredLayers().length && search() -->
-       <p style="font-style:italic;color: #999;"><?php _e('No layers were found.', 'jeo'); ?></p>
+       <p style="font-style:italic;color: #999;"><?php _e('No layers were found.', 'odm'); ?></p>
       <!-- /ko -->
 
       <table class="layers-list available-layers">
@@ -106,12 +106,12 @@
         <tr>
          <td><strong data-bind="text: title"></strong></td>
          <td data-bind="text: type"></td>
-         <td style="width:1%;"><a class="button" data-bind="click: $parent.addLayer" href="javascript:void(0);" title="<?php _e('Add layer', 'jeo'); ?>">+ <?php _e('Add'); ?></a></td>
+         <td style="width:1%;"><a class="button" data-bind="click: $parent.addLayer" href="javascript:void(0);" title="<?php _e('Add layer', 'odm'); ?>">+ <?php _e('Add'); ?></a></td>
         </tr>
        </tbody>
       </table>
 
-      <h4 class="selected-title"><?php _e('Selected layers', 'jeo'); ?></h4>
+      <h4 class="selected-title"><?php _e('Selected layers', 'odm'); ?></h4>
 
       <table class="layers-list selected-layers">
        <tbody class="selected-layers-list">
@@ -122,28 +122,28 @@
            <p data-bind="text: type"></p>
           </td>
           <td>
-           <p><?php _e('Layer options', 'jeo'); ?></p>
+           <p><?php _e('Layer options', 'odm'); ?></p>
            <div class="filter-opts">
             <input type="radio" value="fixed" data-bind="attr: {name: ID + '_filtering_opt', id: ID + '_filtering_opt_fixed'}, checked: $data.filtering" />
-            <label data-bind="attr: {for: ID + '_filtering_opt_fixed'}"><?php _e('Enable', 'jeo'); ?></label> &nbsp; &nbsp; &nbsp;
+            <label data-bind="attr: {for: ID + '_filtering_opt_fixed'}"><?php _e('Enable', 'odm'); ?></label> &nbsp; &nbsp; &nbsp;
             <input  type="radio" value="switch" data-bind="attr: {name: ID + '_filtering_opt', id: ID + '_filtering_opt_switch'}, checked: $data.filtering" />
-            <label data-bind="attr: {for: ID + '_filtering_opt_switch'}"><?php _e('Disable', 'jeo'); ?></label>
+            <label data-bind="attr: {for: ID + '_filtering_opt_switch'}"><?php _e('Disable', 'odm'); ?></label>
             <!--<input type="radio" value="swap"  data-bind="attr: {name: ID + '_filtering_opt', id: ID + '_filtering_opt_swap'}, checked: $data.filtering" />
-            <label data-bind="attr: {for: ID + '_filtering_opt_swap'}"><?php _e('Swapable', 'jeo'); ?></label>-->
+            <label data-bind="attr: {for: ID + '_filtering_opt_swap'}"><?php _e('Swapable', 'odm'); ?></label>-->
 
             <div class="filtering-opts" style="display: none;">
              <!-- ko if: $data.filtering() == 'switch' -->
               <input type="checkbox" data-bind="attr: {id: ID + '_switch_hidden'}, checked: $data.hidden" />
-              <label data-bind="attr: {for: ID + '_switch_hidden'}"><?php _e('Hidden', 'jeo'); ?></label>
+              <label data-bind="attr: {for: ID + '_switch_hidden'}"><?php _e('Hidden', 'odm'); ?></label>
              <!-- /ko -->
              <!-- ko if: $data.filtering() == 'swap' -->
               <input type="radio" data-bind="attr: {id: ID + '_first_swap'}, checked: $data.first_swap" name="_jeo_map_layer_first_swap" />
-              <label data-bind="attr: {for: ID + '_first_swap'}"><?php _e('Default swap option', 'jeo'); ?></label>
+              <label data-bind="attr: {for: ID + '_first_swap'}"><?php _e('Default swap option', 'odm'); ?></label>
              <!-- /ko -->
             </div>
            </div>
           </td>
-          <td style="width:1%;"><a class="button" data-bind="click: $parent.removeLayer" href="javascript:void(0);" title="<?php _e('Remove layer', 'jeo'); ?>"><?php _e('Remove'); ?></a></td>
+          <td style="width:1%;"><a class="button" data-bind="click: $parent.removeLayer" href="javascript:void(0);" title="<?php _e('Remove layer', 'odm'); ?>"><?php _e('Remove'); ?></a></td>
          </tr>
         <!-- /ko -->
        </tbody>
@@ -311,21 +311,21 @@
         ?>
         <div id="layer_settings_box">
             <div class="layer-download-link">
-                <h4><?php _e('Download Page URL', 'jeo'); ?></h4>
+                <h4><?php _e('Download Page URL', 'odm'); ?></h4>
                 <tbody>
                     <tr>
-                        <th><label for="_layer_download_link"><?php _e('Download URL (English)', 'jeo'); ?></label></th>
+                        <th><label for="_layer_download_link"><?php _e('Download URL (English)', 'odm'); ?></label></th>
                         <td>
                             <input id="_layer_download_link" type="text" placeholder="https://" size="40" name="_layer_download_link" value="<?php echo $layer_download_link; ?>" />
-                            <p class="description"><?php _e('A link to a dataset\'s page on CKAN', 'jeo'); ?></p>
+                            <p class="description"><?php _e('A link to a dataset\'s page on CKAN', 'odm'); ?></p>
                         </td>
                     </tr>
                     <?php if(odm_language_manager()->get_the_language_by_site()){ ?>
                     <tr>
-                        <th><label for="_layer_download_link_localization"><?php _e('Download URL ('.odm_language_manager()->get_the_language_by_site().')', 'jeo'); ?></label></th>
+                        <th><label for="_layer_download_link_localization"><?php _e('Download URL ('.odm_language_manager()->get_the_language_by_site().')', 'odm'); ?></label></th>
                         <td>
                             <input id="_layer_download_link_localization" type="text" placeholder="https://" size="40" name="_layer_download_link_localization" value="<?php echo $layer_download_link_localization; ?>" />
-                            <p class="description"><?php _e('A link to a dataset\'s page on CKAN', 'jeo'); ?></p>
+                            <p class="description"><?php _e('A link to a dataset\'s page on CKAN', 'odm'); ?></p>
                         </td>
                     </tr>
                  <?php } ?>
@@ -333,21 +333,21 @@
             </div>
 
             <div class="layer-profilepage-link">
-                <h4><?php _e('Profile Page URL', 'jeo'); ?></h4>
+                <h4><?php _e('Profile Page URL', 'odm'); ?></h4>
                 <tbody>
                     <tr>
-                        <th><label for="_layer_profilepage_link"><?php _e('Profile Page URL (English)', 'jeo'); ?></label></th>
+                        <th><label for="_layer_profilepage_link"><?php _e('Profile Page URL (English)', 'odm'); ?></label></th>
                         <td>
                             <input id="_layer_profilepage_link" type="text" placeholder="https://" size="40" name="_layer_profilepage_link" value="<?php echo $layer_profilepage_link; ?>" />
-                            <p class="description"><?php _e('A link to profile page on Wordpress', 'jeo'); ?></p>
+                            <p class="description"><?php _e('A link to profile page on Wordpress', 'odm'); ?></p>
                         </td>
                     </tr>
                     <?php if(odm_language_manager()->get_the_language_by_site()){ ?>
                     <tr>
-                        <th><label for="_layer_profilepage_link_localization"><?php _e('Profile Page URL ('.odm_language_manager()->get_the_language_by_site().')', 'jeo'); ?></label></th>
+                        <th><label for="_layer_profilepage_link_localization"><?php _e('Profile Page URL ('.odm_language_manager()->get_the_language_by_site().')', 'odm'); ?></label></th>
                         <td>
                             <input id="_layer_profilepage_link_localization" type="text" placeholder="https://" size="40" name="_layer_profilepage_link_localization" value="<?php echo $layer_profilepage_link_localization; ?>" />
-                            <p class="description"><?php _e('A link to profile page on Wordpress', 'jeo'); ?></p>
+                            <p class="description"><?php _e('A link to profile page on Wordpress', 'odm'); ?></p>
                         </td>
                     </tr>
                   <?php } ?>
@@ -355,18 +355,18 @@
             </div>
 
             <div class="layer-type">
-                <h4><?php _e('Layer type', 'jeo'); ?></h4>
+                <h4><?php _e('Layer type', 'odm'); ?></h4>
                 <p>
                      <input type="radio" id="layer_type_tilelayer" name="layer_type" value="tilelayer" <?php if($layer_type == 'tilelayer' || !$layer_type) echo 'checked'; ?> />
-                     <label for="layer_type_tilelayer"><?php _e('Tile layer', 'jeo'); ?></label>
+                     <label for="layer_type_tilelayer"><?php _e('Tile layer', 'odm'); ?></label>
                      <input type="radio" id="layer_type_wmslayer" name="layer_type" value="wmslayer" <?php if($layer_type == 'wmslayer') echo 'checked'; ?> />
-                     <label for="layer_type_wmslayer"><?php _e('WMS layer', 'jeo'); ?></label>
+                     <label for="layer_type_wmslayer"><?php _e('WMS layer', 'odm'); ?></label>
 
                      <input type="radio" id="layer_type_mapbox" name="layer_type" value="mapbox" <?php if($layer_type == 'mapbox') echo 'checked'; ?> />
-                     <label for="layer_type_mapbox"><?php _e('MapBox', 'jeo'); ?></label>
+                     <label for="layer_type_mapbox"><?php _e('MapBox', 'odm'); ?></label>
 
                      <input type="radio" id="layer_type_cartodb" name="layer_type" value="cartodb" <?php if($layer_type == 'cartodb') echo 'checked'; ?> />
-                     <label for="layer_type_cartodb"><?php _e('CartoDB', 'jeo'); ?></label>
+                     <label for="layer_type_cartodb"><?php _e('CartoDB', 'odm'); ?></label>
                 </p>
             </div>
 
@@ -379,30 +379,30 @@
                 ?>
                 <tbody>
                     <tr>
-                        <th><label for="tilelayer_tile_url"><?php _e('URL', 'jeo'); ?></label></th>
+                        <th><label for="tilelayer_tile_url"><?php _e('URL', 'odm'); ?></label></th>
                         <td>
-                            <input id="tilelayer_tile_url" type="text" placeholder="<?php _e('http://{s}.example.com/{z}/{x}/{y}.png', 'jeo'); ?>" size="40" name="_tilelayer_tile_url" value="<?php echo $tileurl; ?>" />
-                            <p class="description"><?php _e('Tilelayer URL. E.g.: http://{s}.example.com/{z}/{x}/{y}.png', 'jeo'); ?></p>
+                            <input id="tilelayer_tile_url" type="text" placeholder="<?php _e('http://{s}.example.com/{z}/{x}/{y}.png', 'odm'); ?>" size="40" name="_tilelayer_tile_url" value="<?php echo $tileurl; ?>" />
+                            <p class="description"><?php _e('Tilelayer URL. E.g.: http://{s}.example.com/{z}/{x}/{y}.png', 'odm'); ?></p>
                         </td>
                     </tr>
                     <tr>
-                        <th><label for="tilelayer_utfgrid_url"><?php _e('UTFGrid URL (optional)', 'jeo'); ?></label></th>
+                        <th><label for="tilelayer_utfgrid_url"><?php _e('UTFGrid URL (optional)', 'odm'); ?></label></th>
                         <td>
-                            <input id="tilelayer_utfgrid_url" type="text" placeholder="<?php _e('http://{s}.example.com/{z}/{x}/{y}.grid.json', 'jeo'); ?>" size="40" name="_tilelayer_utfgrid_url" value="<?php echo $utfgridurl; ?>" />
-                            <p class="description"><?php _e('Optional UTFGrid URL. E.g.: http://{s}.example.com/{z}/{x}/{y}.grid.json', 'jeo'); ?></p>
+                            <input id="tilelayer_utfgrid_url" type="text" placeholder="<?php _e('http://{s}.example.com/{z}/{x}/{y}.grid.json', 'odm'); ?>" size="40" name="_tilelayer_utfgrid_url" value="<?php echo $utfgridurl; ?>" />
+                            <p class="description"><?php _e('Optional UTFGrid URL. E.g.: http://{s}.example.com/{z}/{x}/{y}.grid.json', 'odm'); ?></p>
                         </td>
                     </tr>
                     <tr>
-                        <th><label for="tilelayer_utfgrid_template"><?php _e('UTFGrid Template (optional)', 'jeo'); ?></label></th>
+                        <th><label for="tilelayer_utfgrid_template"><?php _e('UTFGrid Template (optional)', 'odm'); ?></label></th>
                         <td>
                             <textarea id="tilelayer_utfgrid_template" rows="10" cols="40" name="_tilelayer_utfgrid_template"><?php echo $utfgrid_template; ?></textarea>
                             <p class="description"><?php _e('UTFGrid template using mustache.<br/>E.g.: City: {{city}}'); ?></p>
                         </td>
                     </tr>
                     <tr>
-                        <th><label for="tilelayer_tms"><?php _e('TMS', 'jeo'); ?></label></th>
+                        <th><label for="tilelayer_tms"><?php _e('TMS', 'odm'); ?></label></th>
                         <td>
-                            <input id="tilelayer_tms" type="checkbox" name="_tilelayer_tms" <?php if($tms) echo 'checked'; ?> /> <label for="tilelayer_tms"><?php _e('Enable TMS', 'jeo'); ?></label>
+                            <input id="tilelayer_tms" type="checkbox" name="_tilelayer_tms" <?php if($tms) echo 'checked'; ?> /> <label for="tilelayer_tms"><?php _e('Enable TMS', 'odm'); ?></label>
                             <p class="description"><?php _e('Inverses Y axis numbering for tiles (turn this on for TMS services).'); ?></p>
                         </td>
                     </tr>
@@ -421,14 +421,14 @@
                     <tr>
                         <th><label for="wmslayer_tile_url"><?php _e('WMS Service URL', 'opendev'); ?></label></th>
                         <td>
-                            <input id="wmslayer_tile_url" type="text" placeholder="<?php _e('http://{geoserver adress & port}/geoserver/wms', 'jeo'); ?>" size="65" name="_wmslayer_tile_url" value="<?php echo $wmstileurl; ?>" />
+                            <input id="wmslayer_tile_url" type="text" placeholder="<?php _e('http://{geoserver adress & port}/geoserver/wms', 'odm'); ?>" size="65" name="_wmslayer_tile_url" value="<?php echo $wmstileurl; ?>" />
                             <p class="description"><?php _e('Eg. WMS URL: http://geoserver.example.com:8080/geoserver/wms', 'opendev'); ?></p>
                         </td>
                     </tr>
                     <tr>
                         <th><label for="wmslayer_layer_name"><?php _e('Workspaces:Layer Name (English)', 'opendev'); ?></label></th>
                         <td>
-                            <input id="wmslayer_layer_name" type="text" placeholder="<?php _e('Workspaces and Layer name"', 'jeo'); ?>" size="40" name="_wmslayer_layer_name" value="<?php echo $layername; ?>" />
+                            <input id="wmslayer_layer_name" type="text" placeholder="<?php _e('Workspaces and Layer name"', 'odm'); ?>" size="40" name="_wmslayer_layer_name" value="<?php echo $layername; ?>" />
                             <p class="description"><?php _e('Eg. in Geoserver, Energy:Transmission_lines, <strong>Engergy</strong> is workspace name and <strong>Transmission_lines</strong> is layer name.', 'opendev'); ?></p>
                         </td>
                     </tr>
@@ -436,7 +436,7 @@
                     <tr>
                         <th><label for="wmslayer_layer_name_localization"><?php _e('Workspaces:Layer Name ('.odm_language_manager()->get_the_language_by_site().')', 'opendev'); ?></label></th>
                         <td>
-                            <input id="wmslayer_layer_name_localization" type="text" placeholder="<?php _e('Workspaces and Layer name"', 'jeo'); ?>" size="40" name="_wmslayer_layer_name_localization" value="<?php echo $layername_localization; ?>" />
+                            <input id="wmslayer_layer_name_localization" type="text" placeholder="<?php _e('Workspaces and Layer name"', 'odm'); ?>" size="40" name="_wmslayer_layer_name_localization" value="<?php echo $layername_localization; ?>" />
                             <p class="description"><?php _e('Eg. in Geoserver, Energy:Transmission_lines_kh, <strong>Engergy</strong> is workspace name and <strong>Transmission_lines</strong> is layer name.', 'opendev'); ?></p>
                         </td>
                      </tr>
@@ -451,10 +451,10 @@
                         </td>
                     </tr>
                     <tr>
-                        <th><label for="wmslayer_transparent"><?php _e('Transparent', 'jeo'); ?></label></th>
+                        <th><label for="wmslayer_transparent"><?php _e('Transparent', 'odm'); ?></label></th>
                         <td>
                             <?php $is_new_page = get_current_screen(); // Transparent is checked by default. ?>
-                            <input id="wmslayer_transparent" type="checkbox" name="_wmslayer_transparent" <?php if($transparent) echo 'checked'; else if ( $is_new_page->action =="add") echo 'checked'; ?> /> <label for="wmslayer_transparent"><?php _e('Transparent', 'jeo'); ?></label>
+                            <input id="wmslayer_transparent" type="checkbox" name="_wmslayer_transparent" <?php if($transparent) echo 'checked'; else if ( $is_new_page->action =="add") echo 'checked'; ?> /> <label for="wmslayer_transparent"><?php _e('Transparent', 'odm'); ?></label>
                             <p class="description"><?php _e('Enable it to make transparent the layer of WMS.'); ?></p>
                         </td>
                     </tr>
@@ -464,10 +464,10 @@
                 <?php $mapbox_id = $post ? get_post_meta($post->ID, '_mapbox_id', true) : ''; ?>
                 <tbody>
                     <tr>
-                        <th><label for="mapbox_id"><?php _e('MapBox ID', 'jeo'); ?></label></th>
+                        <th><label for="mapbox_id"><?php _e('MapBox ID', 'odm'); ?></label></th>
                         <td>
                             <input id="mapbox_id" type="text" placeholder="examples.map-20v6611k" size="40" name="_mapbox_id" value="<?php echo $mapbox_id; ?>" />
-                            <p class="description"><?php _e('MapBox map ID. E.g.: examples.map-20v6611k', 'jeo'); ?></p>
+                            <p class="description"><?php _e('MapBox map ID. E.g.: examples.map-20v6611k', 'odm'); ?></p>
                         </td>
                     </tr>
                 </tbody>
@@ -491,60 +491,60 @@
               ?>
               <tbody>
                 <tr>
-                  <th><?php _e('Visualization type', 'jeo'); ?></th>
+                  <th><?php _e('Visualization type', 'odm'); ?></th>
                   <td>
                     <input name="_cartodb_type" id="cartodb_viz_type_viz" type="radio" value="viz" <?php if($cartodb_type == 'viz' || !$cartodb_type) echo 'checked'; ?> />
-                    <label for="cartodb_viz_type_viz"><?php _e('Visualization', 'jeo'); ?></label>
+                    <label for="cartodb_viz_type_viz"><?php _e('Visualization', 'odm'); ?></label>
                     <input name="_cartodb_type" id="cartodb_viz_type_custom" type="radio" value="custom" disabled <?php if($cartodb_type == 'custom') echo 'checked'; ?> />
-                    <label for="cartodb_viz_type_custom"><?php _e('Advanced (build from your tables)', 'jeo'); ?> - <?php _e('coming soon', 'jeo'); ?></label>
+                    <label for="cartodb_viz_type_custom"><?php _e('Advanced (build from your tables)', 'odm'); ?> - <?php _e('coming soon', 'odm'); ?></label>
                   </td>
                 </tr>
                 <tr class="subopt viz_type_viz">
-                <th><label for="cartodb_viz_url"><?php _e('CartoDB URL (English)', 'jeo'); ?></label></th>
+                <th><label for="cartodb_viz_url"><?php _e('CartoDB URL (English)', 'odm'); ?></label></th>
                   <td>
                     <input id="cartodb_viz_url" type="text" placeholder="http://user.cartodb.com/api/v2/viz/621d23a0-5eaa-11e4-ab03-0e853d047bba/viz.json" size="40" name="_cartodb_viz_url" value="<?php echo $vizurl; ?>" />
-                    <p class="description"><?php _e('CartoDB visualization URL.<br/>E.g.: http://infoamazonia.cartodb.com/api/v2/viz/621d23a0-5eaa-11e4-ab03-0e853d047bba/viz.json', 'jeo'); ?></p>
+                    <p class="description"><?php _e('CartoDB visualization URL.<br/>E.g.: http://infoamazonia.cartodb.com/api/v2/viz/621d23a0-5eaa-11e4-ab03-0e853d047bba/viz.json', 'odm'); ?></p>
                   </td>
                 </tr>
                 <?php if(odm_language_manager()->get_the_language_by_site()){ ?>
                 <tr class="subopt viz_type_viz">
-                  <th><label for="cartodb_viz_url_localization"><?php _e('CartoDB URL ('.odm_language_manager()->get_the_language_by_site().')', 'jeo'); ?></label></th>
+                  <th><label for="cartodb_viz_url_localization"><?php _e('CartoDB URL ('.odm_language_manager()->get_the_language_by_site().')', 'odm'); ?></label></th>
                   <td>
                     <input id="cartodb_viz_url_localization" type="text" placeholder="http://user.cartodb.com/api/v2/viz/621d23a0-5eaa-11e4-ab03-0e853d047bba/viz.json" size="40" name="_cartodb_viz_url_localization" value="<?php echo $vizurl_localization; ?>" />
-                    <p class="description"><?php _e('CartoDB visualization URL.<br/>E.g.: http://infoamazonia.cartodb.com/api/v2/viz/621d23a0-5eaa-11e4-ab03-0e853d047bba/viz.json', 'jeo'); ?></p>
+                    <p class="description"><?php _e('CartoDB visualization URL.<br/>E.g.: http://infoamazonia.cartodb.com/api/v2/viz/621d23a0-5eaa-11e4-ab03-0e853d047bba/viz.json', 'odm'); ?></p>
                   </td>
                 </tr>
                 <?php } ?>
                 <tr class="subopt viz_type_custom">
-                  <th><label for="cartodb_viz_username"><?php _e('Username', 'jeo'); ?></label></th>
+                  <th><label for="cartodb_viz_username"><?php _e('Username', 'odm'); ?></label></th>
                   <td>
                     <input id="cartodb_viz_username" type="text" placeholder="johndoe" name="_cartodb_username" value="<?php echo $username; ?>" />
                     <p class="description"><?php _e('Your CartoDB username.'); ?></p>
                   </td>
                 </tr>
                 <tr class="subopt viz_type_custom">
-                  <th><label for="cartodb_viz_table"><?php _e('Table', 'jeo'); ?></label></th>
+                  <th><label for="cartodb_viz_table"><?php _e('Table', 'odm'); ?></label></th>
                   <td>
                     <input id="cartodb_viz_table" type="text" placeholder="deforestation_2012" name="_cartodb_table" value="<?php echo $table; ?>" />
                     <p class="description"><?php _e('The CartoDB table you\'d like to visualize.'); ?></p>
                   </td>
                 </tr>
                 <tr class="subopt viz_type_custom">
-                  <th><label for="cartodb_viz_where"><?php _e('Where (optional)', 'jeo'); ?></label></th>
+                  <th><label for="cartodb_viz_where"><?php _e('Where (optional)', 'odm'); ?></label></th>
                   <td>
                     <textarea id="cartodb_viz_where" rows="3" cols="40" name="_cartodb_where"><?php echo $where; ?></textarea>
                     <p class="description"><?php _e('Query data from your table.<br/>E.g.: region = "north"'); ?></p>
                   </td>
                 </tr>
                 <tr class="subopt viz_type_custom">
-                  <th><label for="cartodb_viz_cartocss"><?php _e('CartoCSS', 'jeo'); ?></label></th>
+                  <th><label for="cartodb_viz_cartocss"><?php _e('CartoCSS', 'odm'); ?></label></th>
                   <td>
                     <textarea id="cartodb_viz_cartocss" rows="10" cols="40" name="_cartodb_cartocss"><?php echo $cartocss; ?></textarea>
                     <p class="description"><?php printf(__('Styles for your table. <a href="%s" target="_blank">Learn more</a>.'), 'https://www.mapbox.com/tilemill/docs/manual/carto/'); ?></p>
                   </td>
                 </tr>
                 <tr class="subopt viz_type_custom">
-                  <th><label for="cartodb_viz_template"><?php _e('Template', 'jeo'); ?></label></th>
+                  <th><label for="cartodb_viz_template"><?php _e('Template', 'odm'); ?></label></th>
                   <td>
                     <textarea id="cartodb_viz_template" rows="10" cols="40" name="_cartodb_template"><?php echo $template; ?></textarea>
                     <p class="description"><?php _e('UTFGrid template using mustache.<br/>E.g.: City: {{city}}'); ?></p>
@@ -748,7 +748,7 @@
      if($map_layers) {
         foreach($map_layers as $l) {
            $layer = $this->get_layer($l['ID']);
-           $layer['filtering'] = $l['filtering']; 
+           $layer['filtering'] = $l['filtering'];
 
            if($filter == "baselayer") {
                if($layer['map_category'] == "base-layers"){

--- a/inc/post-types/stories.php
+++ b/inc/post-types/stories.php
@@ -10,6 +10,8 @@ class Odm_Story {
 	function __construct() {
 
 		add_action('init', array($this, 'register_post_type'));
+    add_action('add_meta_boxes', array($this, 'add_meta_box'));
+    add_action('save_post', array($this, 'save_post_data'));
 
 	}
 
@@ -52,6 +54,104 @@ class Odm_Story {
 		register_post_type( 'story', $args );
 
 	}
+
+	public function add_meta_box()
+  {
+    add_meta_box(
+     'full_width_middle_content',
+     __('Full Width Middle Content', 'odm'),
+     array($this, 'full_width_middle_content_box'),
+     'story',
+     'advanced',
+     'high'
+    );
+
+  }//metabox
+
+	public function full_width_middle_content_box($post = false)
+  {
+    $full_width_middle_content = get_post_meta($post->ID, '_full_width_middle_content', true);
+    $full_width_middle_content_localization = get_post_meta($post->ID, '_full_width_middle_content_localization', true);
+    ?>
+    <div id="multiple-site">
+      <input type="radio" id="middle_content_en" class="en" name="language_site1" value="en" checked />
+      <label for="middle_content_en"><?php _e('ENGLISH', 'odm'); ?></label> &nbsp;
+      <?php if (odm_language_manager()->get_the_language_by_site() != "English"): ?>
+        <input type="radio" id="middle_content_localization" class="localization" name="language_site1" value="localization" />
+        <label for="middle_content_localization"><?php _e(odm_language_manager()->get_the_language_by_site(), 'odm');  ?></label>
+      <?php endif; ?>
+
+    </div>
+
+    <div id="middle_content_box">
+      <div class="language_settings language-en">
+        <table class="form-table middle_content_box">
+          <tbody>
+            <tr>
+            <td><label for="_full_width_middle_content"><?php _e('Full width content (English)', 'odm');
+            ?></label>
+            </br>
+            <textarea name="_full_width_middle_content" style="width:100%;height: 50px;" placeholder=""><?php echo $full_width_middle_content; ?></textarea>
+            <p class="description"><?php _e('Any content can add to under the Editor content and sidebar and  full width of website even the iframe.', 'odm');
+            ?></p>
+            </td>
+           </tr>
+          </tbody>
+        </table>
+      </div>
+      <?php if (odm_language_manager()->get_the_language_by_site() != "English") { ?>
+      <div class="language_settings language-localization">
+        <table class="form-table form-table-localization middle_content_box">
+          <tbody>
+            <tr>
+            <td><label for="_full_width_middle_content_localization"><?php _e('Full width content (('.odm_language_manager()->get_the_language_by_site().')', 'odm');
+            ?></label>
+            </br>
+            <textarea name="_full_width_middle_content_localization" style="width:100%;height: 50px;" placeholder=""><?php echo $full_width_middle_content_localization; ?></textarea>
+            <p class="description"><?php _e('Any content can add to under the Editor content and sidebar and  full width of website even the iframe.', 'odm');
+            ?></p>
+            </td>
+           </tr>
+          </tbody>
+        </table>
+      </div>
+      <?php
+      }
+      ?>
+    </div>
+    <?php
+  }
+
+	public function save_post_data($post_id)
+  {
+    global $post;
+    if (isset($post->ID) && get_post_type($post->ID) == 'story') {
+
+      if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+      }
+
+      if (defined('DOING_AJAX') && DOING_AJAX) {
+        return;
+      }
+
+      if (false !== wp_is_post_revision($post_id)) {
+        return;
+      }
+
+      if (!current_user_can('edit_post')) {
+        return;
+      }
+
+      if (isset($_POST['_full_width_middle_content'])) {
+        update_post_meta($post_id, '_full_width_middle_content', $_POST['_full_width_middle_content']);
+      }
+
+      if (isset($_POST['_full_width_middle_content_localization'])) {
+        update_post_meta($post_id, '_full_width_middle_content_localization', $_POST['_full_width_middle_content_localization']);
+			}
+    }
+  }
 
 }
 

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -250,7 +250,7 @@ class Odm_Options
         ?>
 
     <div>
-     <?php _e('Select base layer', 'jeo');
+     <?php _e('Select base layer', 'odm');
         ?>
      <select name="odm_options[map_data][base_layer][type]" id="baselayer_drop_down">
       <option value="openstreetmap" <?php echo $select_base_layer == 'openstreetmap' ? ' selected="selected"' : '';
@@ -264,75 +264,75 @@ class Odm_Options
       <option value="stamen_watercolor" <?php echo $select_base_layer == 'stamen_watercolor' ? ' selected="selected"' : '';
         ?>>Stamen Watercolor</option>
       <option value="stamen_terrain" <?php echo $select_base_layer == 'stamen_terrain' ? ' selected="selected"' : '';
-        ?> >Stamen Terrain <?php _e('(USA Only)', 'jeo');
+        ?> >Stamen Terrain <?php _e('(USA Only)', 'odm');
         ?></option>
       <option value="custom" <?php echo $select_base_layer == 'custom' ? ' selected="selected"' : '';
-        ?> ><?php _e('Custom', 'jeo');
+        ?> ><?php _e('Custom', 'odm');
         ?></option>
       <option value="none" <?php echo $select_base_layer == 'none' ? ' selected="selected"' : '';
-        ?> ><?php _e('None', 'jeo');
+        ?> ><?php _e('None', 'odm');
         ?></option>
      </select>
-     <input type="text" name="odm_options[map_data][base_layer][url]" id="baselayer_url_box" class="layer_title" size="40" placeholder="<?php _e('Enter layer URL', 'jeo');
+     <input type="text" name="odm_options[map_data][base_layer][url]" id="baselayer_url_box" class="layer_title" size="40" placeholder="<?php _e('Enter layer URL', 'odm');
         ?>" value="<?php echo $base_layer_url;
         ?>" />
     </div>
 
-    <p><a class="button-primary preview-map" href="#"><?php _e('Update preview', 'jeo');
+    <p><a class="button-primary preview-map" href="#"><?php _e('Update preview', 'odm');
         ?></a></p>
    </div>
-   <h3><?php _e('Preview map', 'jeo');
+   <h3><?php _e('Preview map', 'odm');
         ?></h3>
    <div class="map-container">
     <div id="map_preview" class="map"></div>
    </div>
    <div class="map-settings clearfix">
-    <h3><?php _e('Map settings', 'jeo');
+    <h3><?php _e('Map settings', 'odm');
         ?></h3>
     <div class="current map-setting">
-     <h4><?php _e('Currently viewing', 'jeo');
+     <h4><?php _e('Currently viewing', 'odm');
         ?></h4>
      <table>
       <tr>
-       <td><?php _e('Center', 'jeo');
+       <td><?php _e('Center', 'odm');
         ?></td>
        <td><span class="center"></span></td>
       </tr>
       <tr>
-       <td><?php _e('Zoom', 'jeo');
+       <td><?php _e('Zoom', 'odm');
         ?></td>
        <td><span class="zoom"></span></td>
       </tr>
       <tr>
-       <td><?php _e('East', 'jeo');
+       <td><?php _e('East', 'odm');
         ?></td>
        <td><span class="east"></span></td>
       </tr>
       <tr>
-       <td><?php _e('North', 'jeo');
+       <td><?php _e('North', 'odm');
         ?></td>
        <td><span class="north"></span></td>
       </tr>
       <tr>
-       <td><?php _e('South', 'jeo');
+       <td><?php _e('South', 'odm');
         ?></td>
        <td><span class="south"></span></td>
       </tr>
       <tr>
-       <td><?php _e('West', 'jeo');
+       <td><?php _e('West', 'odm');
         ?></td>
        <td><span class="west"></span></td>
       </tr>
      </table>
     </div>
     <div class="centerzoom map-setting">
-     <h4><?php _e('Map center & zoom', 'jeo');
+     <h4><?php _e('Map center & zoom', 'odm');
         ?></h4>
-     <p><a class="button set-map-centerzoom"><?php _e('Set current as map center & zoom', 'jeo');
+     <p><a class="button set-map-centerzoom"><?php _e('Set current as map center & zoom', 'odm');
         ?></a></p>
      <table>
       <tr>
-       <td><?php _e('Center', 'jeo');
+       <td><?php _e('Center', 'odm');
         ?></td>
        <td><span class="center">(<?php if (isset($map_data['center'])) {
     echo $map_data['center']['lat'];
@@ -343,7 +343,7 @@ class Odm_Options
         ?>)</span></td>
       </tr>
       <tr>
-       <td><?php _e('Zoom', 'jeo');
+       <td><?php _e('Zoom', 'odm');
         ?></td>
        <td><span class="zoom"><?php if (isset($map_data['zoom'])) {
     echo $map_data['zoom'];
@@ -351,26 +351,26 @@ class Odm_Options
         ?></span></td>
       </tr>
       <tr>
-       <td><label for="min-zoom-input"><?php _e('Min zoom', 'jeo');
+       <td><label for="min-zoom-input"><?php _e('Min zoom', 'odm');
         ?></label></td>
        <td>
         <input type="text" size="2" id="min-zoom-input" value="<?php if (isset($map_data['min_zoom'])) {
     echo $map_data['min_zoom'];
 }
         ?>" name="odm_options[map_data][min_zoom]" />
-        <a class="button set-min-zoom" href="#"><?php _e('Current', 'jeo');
+        <a class="button set-min-zoom" href="#"><?php _e('Current', 'odm');
         ?></a>
        </td>
       </tr>
       <tr>
-       <td><label for="max-zoom-input"><?php _e('Max zoom', 'jeo');
+       <td><label for="max-zoom-input"><?php _e('Max zoom', 'odm');
         ?></label></td>
        <td>
         <input type="text" size="2" id="max-zoom-input" value="<?php if (isset($map_data['center'])) {
     echo $map_data['max_zoom'];
 }
         ?>" name="odm_options[map_data][max_zoom]" />
-        <a class="button set-max-zoom" href="#"><?php _e('Current', 'jeo');
+        <a class="button set-max-zoom" href="#"><?php _e('Current', 'odm');
         ?></a>
        </td>
       </tr>
@@ -389,13 +389,13 @@ class Odm_Options
         ?>" />
     </div>
     <div class="pan-limits map-setting">
-     <h4><?php _e('Pan limits', 'jeo');
+     <h4><?php _e('Pan limits', 'odm');
         ?></h4>
-     <p><a class="button set-map-pan"><?php _e('Set current as map panning limits', 'jeo');
+     <p><a class="button set-map-pan"><?php _e('Set current as map panning limits', 'odm');
         ?></a></p>
      <table>
       <tr>
-       <td><?php _e('East', 'jeo');
+       <td><?php _e('East', 'odm');
         ?></td>
        <td><span class="east"><?php if (isset($map_data['pan_limits'])) {
     echo $map_data['pan_limits']['east'];
@@ -403,7 +403,7 @@ class Odm_Options
         ?></span></td>
       </tr>
       <tr>
-       <td><?php _e('North', 'jeo');
+       <td><?php _e('North', 'odm');
         ?></td>
        <td><span class="north"><?php if (isset($map_data['pan_limits'])) {
     echo $map_data['pan_limits']['north'];
@@ -411,7 +411,7 @@ class Odm_Options
         ?></span></td>
       </tr>
       <tr>
-       <td><?php _e('South', 'jeo');
+       <td><?php _e('South', 'odm');
         ?></td>
        <td><span class="south"><?php if (isset($map_data['pan_limits'])) {
     echo $map_data['pan_limits']['south'];
@@ -419,7 +419,7 @@ class Odm_Options
         ?></span></td>
       </tr>
       <tr>
-       <td><?php _e('West', 'jeo');
+       <td><?php _e('West', 'odm');
         ?></td>
        <td><span class="west"><?php if (isset($map_data['pan_limits'])) {
     echo $map_data['pan_limits']['west'];
@@ -445,26 +445,26 @@ class Odm_Options
         ?>" />
     </div>
     <div class="geocode map-setting">
-     <h4><?php _e('Enable geocoding service', 'jeo');
+     <h4><?php _e('Enable geocoding service', 'odm');
         ?></h4>
      <p>
       <input class="enable-geocode" id="enable_geocode" type="checkbox" name="odm_options[map_data][geocode]" <?php if (isset($map_data['geocode']) && $map_data['geocode']) {
     echo 'checked';
 }
         ?> />
-      <label for="enable_geocode"><?php _e('Enable geocode search service', 'jeo');
+      <label for="enable_geocode"><?php _e('Enable geocode search service', 'odm');
         ?></label>
      </p>
     </div>
     <div class="handlers map-setting">
-     <h4><?php _e('Map handlers', 'jeo');
+     <h4><?php _e('Map handlers', 'odm');
         ?></h4>
      <p>
       <input class="disable-mousewheel" id="disable_mousewheel" type="checkbox" name="odm_options[map_data][disable_mousewheel]" <?php if (isset($map_data['disable_mousewheel']) && $map_data['disable_mousewheel']) {
     echo 'checked';
 }
         ?> />
-      <label for="disable_mousewheel"><?php _e('Disable mousewheel zooming', 'jeo');
+      <label for="disable_mousewheel"><?php _e('Disable mousewheel zooming', 'odm');
         ?></label>
      </p>
     </div>
@@ -472,11 +472,11 @@ class Odm_Options
         ?>
    </div>
    <p>
-    <a class="button-primary preview-map" href="#"><?php _e('Update preview', 'jeo');
+    <a class="button-primary preview-map" href="#"><?php _e('Update preview', 'odm');
         ?></a>
-    <input type="checkbox" class="toggle-preview-mode" id="toggle_preview_mode" checked /> <label for="toggle_preview_mode"><strong><?php _e('Preview mode', 'jeo');
+    <input type="checkbox" class="toggle-preview-mode" id="toggle_preview_mode" checked /> <label for="toggle_preview_mode"><strong><?php _e('Preview mode', 'odm');
         ?></strong></label>
-    <i><?php _e("(preview mode doesn't apply zoom range nor pan limits setup)", 'jeo');
+    <i><?php _e("(preview mode doesn't apply zoom range nor pan limits setup)", 'odm');
         ?></i>
    </p>
   </div>

--- a/page.php
+++ b/page.php
@@ -16,7 +16,7 @@
 			<?php the_content(); ?>
 			<?php
 			wp_link_pages( array(
-				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'jeo' ) . '</span>',
+				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'odm' ) . '</span>',
 				'after'       => '</div>',
 				'link_before' => '<span>',
 				'link_after'  => '</span>',

--- a/single-map.php
+++ b/single-map.php
@@ -43,7 +43,7 @@ if(have_posts()) :
 <section class="container">
 	<header class="row">
 		<div class="eight columns">
-			<h2><?php _e('Latest articles on', 'jeo'); ?> <?php the_title(); ?></H2>
+			<h2><?php _e('Latest articles on', 'odm'); ?> <?php the_title(); ?></H2>
 		</div>
 		<div class="eight columns">
 			<?php get_template_part('section', 'query-actions'); ?>

--- a/single-story.php
+++ b/single-story.php
@@ -26,6 +26,19 @@
         </div>
       </section>
 
+			<?php
+			$middle_content = get_post_meta(get_the_ID(), '_full_width_middle_content', true);
+			if (odm_language_manager()->get_current_language() != 'en') {
+    		$middle_content = get_post_meta(get_the_ID(), '_full_width_middle_content_localization', true);
+  		}
+			if($middle_content): ?>
+      <div class="row">
+        <div class="sixteen columns">
+          <?php echo "<div class='iframe-visualitation'>".$middle_content."</div>"; ?>
+        </div>
+      </div>
+  		<?php endif; ?>
+
       <section class="container">
     		<div class="row">
     			<div class="ten columns offset-by-three">

--- a/single-story.php
+++ b/single-story.php
@@ -32,13 +32,9 @@
     		$middle_content = get_post_meta(get_the_ID(), '_full_width_middle_content_localization', true);
   		}
 			if($middle_content): ?>
-			<section class="container">
-	      <div class="row">
-	        <div class="sixteen columns">
-	          <?php echo "<div class='iframe-visualitation'>".$middle_content."</div>"; ?>
-	        </div>
-	      </div>
-			</section>
+        <div style="width: 100%;">
+          <?php echo "<div class='iframe-visualitation'>".$middle_content."</div>"; ?>
+        </div>
   		<?php endif; ?>
 
       <section class="container">

--- a/single-story.php
+++ b/single-story.php
@@ -32,11 +32,13 @@
     		$middle_content = get_post_meta(get_the_ID(), '_full_width_middle_content_localization', true);
   		}
 			if($middle_content): ?>
-      <div class="row">
-        <div class="sixteen columns">
-          <?php echo "<div class='iframe-visualitation'>".$middle_content."</div>"; ?>
-        </div>
-      </div>
+			<section class="container">
+	      <div class="row">
+	        <div class="sixteen columns">
+	          <?php echo "<div class='iframe-visualitation'>".$middle_content."</div>"; ?>
+	        </div>
+	      </div>
+			</section>
   		<?php endif; ?>
 
       <section class="container">

--- a/single-topic.php
+++ b/single-topic.php
@@ -38,7 +38,7 @@
             </div>
             <?php
             wp_link_pages(array(
-              'before' => '<div class="page-links"><span class="page-links-title">'.__('Pages:', 'jeo').'</span>',
+              'before' => '<div class="page-links"><span class="page-links-title">'.__('Pages:', 'odm').'</span>',
               'after' => '</div>',
               'link_before' => '<span>',
               'link_after' => '</span>',

--- a/single.php
+++ b/single.php
@@ -36,7 +36,7 @@
 						</section>
             <?php
               wp_link_pages(array(
-                      'before' => '<div class="page-links"><span class="page-links-title">'.__('Pages:', 'jeo').'</span>',
+                      'before' => '<div class="page-links"><span class="page-links-title">'.__('Pages:', 'odm').'</span>',
                       'after' => '</div>',
                       'link_before' => '<span>',
                       'link_after' => '</span>',


### PR DESCRIPTION
@DBishton This PR implements a solution which allow editors to specify HTML content to be shown full-width on top of stories.

On https://pp.opendevelopmentmekong.net/stories/international-influences/ you will find an example of a story with the so-called **full-width middle content** which can now be specified on **Stories** as pictured below:

![screenshot from 2016-11-29 11-58-28](https://cloud.githubusercontent.com/assets/384894/20707407/a3907e60-b62b-11e6-986c-512d84469846.png)

@DBishton please review on PP and re-openm the issue https://github.com/OpenDevelopmentMekong/wp-odm_theme/issues/397 in case somebody does not work as expected