### PR TITLE
Fixes  #998, Fixes #989

### DIFF
--- a/inc/summary.php
+++ b/inc/summary.php
@@ -38,7 +38,7 @@ class Odm_Summary {
 
 					$el->setAttribute('id', sanitize_title($name));
 					$el->setAttribute('class', 'summary-item');
-					$link = $dom->createElement('a');
+					$link = $dom->createElement('h4');
 					$link->setAttribute('href', '#' . sanitize_title($name));
 					$link->setAttribute("title", $name);
 					//$link->nodeValue = htmlspecialchars($name);

--- a/inc/summary.php
+++ b/inc/summary.php
@@ -38,8 +38,7 @@ class Odm_Summary {
 
 					$el->setAttribute('id', sanitize_title($name));
 					$el->setAttribute('class', 'summary-item');
-					$header = $dom->createElement('h4');
-					$link = $header->createElement('a');
+					$link = $dom->createElement('a');
 					$link->setAttribute('href', '#' . sanitize_title($name));
 					$link->setAttribute("title", $name);
 					//$link->nodeValue = htmlspecialchars($name);
@@ -53,7 +52,7 @@ class Odm_Summary {
 					*/
 
 					$el->nodeValue = htmlspecialchars($name);
-					$el->appendChild($header);
+					$el->appendChild($link);
 
 				}
 

--- a/inc/summary.php
+++ b/inc/summary.php
@@ -39,7 +39,7 @@ class Odm_Summary {
 					$el->setAttribute('id', sanitize_title($name));
 					$el->setAttribute('class', 'summary-item');
 					$header = $dom->createElement('h4');
-					$link = $dom->createElement('a');
+					$link = $header->createElement('a');
 					$link->setAttribute('href', '#' . sanitize_title($name));
 					$link->setAttribute("title", $name);
 					//$link->nodeValue = htmlspecialchars($name);
@@ -53,7 +53,6 @@ class Odm_Summary {
 					*/
 
 					$el->nodeValue = htmlspecialchars($name);
-					$header->appendChild($link);
 					$el->appendChild($header);
 
 				}

--- a/inc/summary.php
+++ b/inc/summary.php
@@ -38,7 +38,7 @@ class Odm_Summary {
 
 					$el->setAttribute('id', sanitize_title($name));
 					$el->setAttribute('class', 'summary-item');
-					$link = $dom->createElement('h4');
+					$link = $dom->createElement('a');
 					$link->setAttribute('href', '#' . sanitize_title($name));
 					$link->setAttribute("title", $name);
 					//$link->nodeValue = htmlspecialchars($name);

--- a/inc/summary.php
+++ b/inc/summary.php
@@ -38,6 +38,7 @@ class Odm_Summary {
 
 					$el->setAttribute('id', sanitize_title($name));
 					$el->setAttribute('class', 'summary-item');
+					$header = $dom->createElement('h4');
 					$link = $dom->createElement('a');
 					$link->setAttribute('href', '#' . sanitize_title($name));
 					$link->setAttribute("title", $name);
@@ -52,7 +53,8 @@ class Odm_Summary {
 					*/
 
 					$el->nodeValue = htmlspecialchars($name);
-					$el->appendChild($link);
+					$header->appendChild($link);
+					$el->appendChild($header);
 
 				}
 

--- a/inc/templates/post-grid-single-1-cols.php
+++ b/inc/templates/post-grid-single-1-cols.php
@@ -11,13 +11,14 @@
 	?>
 
 <div class="sixteen columns post-grid-item<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
-	<div class="grid-content-wrapper">		
+	<div class="grid-content-wrapper">
 		<div class="meta">
-			
+
 			<?php
 	      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 				$title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language()); ?>
-			<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
+			<h5>
+				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
 				<?php
 					if ($show_post_type):
 						$post_type_name = get_post_type($post->ID); ?>
@@ -25,7 +26,8 @@
 				<?php
 					endif; ?>
 				<?php echo $title; ?>
-			</a>
+				</a>
+			</h5>
 			<?php
 				if ($show_meta):
 					echo_post_meta($post,$meta_fields,$order,null,null);

--- a/inc/templates/post-grid-single-2-cols.php
+++ b/inc/templates/post-grid-single-2-cols.php
@@ -11,21 +11,23 @@
 	?>
 
 <div class="eight columns post-grid-item<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
-	<div class="grid-content-wrapper">		
+	<div class="grid-content-wrapper">
 		<div class="meta">
-			
+
 			<?php
 	      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 				$title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language()); ?>
-				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
-					<?php
-						if ($show_post_type):
-							$post_type_name = get_post_type($post->ID); ?>
-							<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
-					<?php
-						endif; ?>
-					<?php echo $title; ?>
-				</a>
+				<h5>
+					<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
+						<?php
+							if ($show_post_type):
+								$post_type_name = get_post_type($post->ID); ?>
+								<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
+						<?php
+							endif; ?>
+						<?php echo $title; ?>
+					</a>
+				</h5>
 			<?php
 				if ($show_meta):
 					echo_post_meta($post,$meta_fields,$order,null,null);

--- a/inc/templates/post-grid-single-4-cols-caption-below.php
+++ b/inc/templates/post-grid-single-4-cols-caption-below.php
@@ -12,19 +12,21 @@
 <div class="four columns post-grid-item post-grid-item-caption-below <?php echo odm_country_manager()->get_current_country(); ?>-bgdarkcolor<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
 	<div class="grid-content-wrapper">
 		<?php if ($show_meta): ?>
-		<div class="meta">				
+		<div class="meta">
 				<?php
 		      $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 					$title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language()); ?>
-					<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
-						<?php
-							if ($show_post_type):
-								$post_type_name = get_post_type($post->ID); ?>
-								<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
-						<?php
-							endif; ?>
-						<?php echo $title; ?>
-					</a>
+					<h5>
+						<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
+							<?php
+								if ($show_post_type):
+									$post_type_name = get_post_type($post->ID); ?>
+									<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
+							<?php
+								endif; ?>
+							<?php echo $title; ?>
+						</a>
+					</h5>
 					<?php
 				if (isset($post->description) && $post->description != "") :?>
 					<div class="post-grid-item-list">

--- a/inc/templates/post-grid-single-4-cols-caption-below.php
+++ b/inc/templates/post-grid-single-4-cols-caption-below.php
@@ -9,7 +9,7 @@
 	$extra_classes = isset($params["extra_classes"]) ? $params["extra_classes"] : null;
 	?>
 
-<div class="four columns post-grid-item post-grid-item-caption-bolow <?php echo odm_country_manager()->get_current_country(); ?>-bgdarkcolor<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
+<div class="four columns post-grid-item post-grid-item-caption-below <?php echo odm_country_manager()->get_current_country(); ?>-bgdarkcolor<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
 	<div class="grid-content-wrapper">
 		<?php if ($show_meta): ?>
 		<div class="meta">				

--- a/inc/templates/post-grid-single-4-cols.php
+++ b/inc/templates/post-grid-single-4-cols.php
@@ -11,20 +11,22 @@
 	?>
 
 <div class="four columns post-grid-item<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
-	<div class="grid-content-wrapper">		
-		<div class="meta">			
+	<div class="grid-content-wrapper">
+		<div class="meta">
 			<?php
 				$link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 				$title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language()); ?>
-				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
-					<?php
-						if ($show_post_type):
-							$post_type_name = get_post_type($post->ID); ?>
-							<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
-					<?php
-						endif; ?>
-					<?php echo $title; ?>
-				</a>
+				<h5>
+					<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $title; ?>">
+						<?php
+							if ($show_post_type):
+								$post_type_name = get_post_type($post->ID); ?>
+								<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
+						<?php
+							endif; ?>
+						<?php echo $title; ?>
+					</a>
+				</h5>
 			<?php
 				if ($show_meta):
 					echo_post_meta($post,$meta_fields,$order,null,null);

--- a/inc/templates/post-link-single-1-cols.php
+++ b/inc/templates/post-link-single-1-cols.php
@@ -6,7 +6,7 @@
 <div class="sixteen columns">
 	<div class="post-list-item single_result_container">
 		<p>
-			<h3>
+			<h5>
 				<?php
 					$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
 				 ?>
@@ -19,7 +19,7 @@
 						endif; ?>
 					<?php echo $localized_title; ?>
 				</a>
-			</h3>
+			</h5>
 		</p>
 	</div>
 </div>

--- a/inc/templates/post-list-single-1-cols.php
+++ b/inc/templates/post-list-single-1-cols.php
@@ -36,24 +36,22 @@
 				</a>
 			</h5>
 		<?php else: ?>
-			<p>
-				<h5>
-					<?php
-						$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
-					 ?>
-					<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
+			<h5>
+				<?php
+					$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
+				 ?>
+				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
 
+				<?php
+					if ($show_post_type):
+						$post_type_name = get_post_type($post->ID); ?>
+						<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
 					<?php
-						if ($show_post_type):
-							$post_type_name = get_post_type($post->ID); ?>
-							<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
-						<?php
-						endif; ?>
+					endif; ?>
 
-							<?php echo $localized_title; ?>
-						</a>
-				</h5>
-			</p>
+						<?php echo $localized_title; ?>
+					</a>
+			</h5>
 		<?php endif; ?>
 
 		<?php

--- a/inc/templates/post-list-single-1-cols.php
+++ b/inc/templates/post-list-single-1-cols.php
@@ -15,7 +15,7 @@
 	$header_tag = isset($params["header_tag"]) ? $params["header_tag"] : false;
 	$order = isset($params["order"]) ? $params["order"] : "metadata_created";
 	$extra_classes = isset($params["extra_classes"]) ? $params["extra_classes"] : null;
-	
+
 ?>
 
 <div class="sixteen columns<?php if (isset($extra_classes)): echo " ". $extra_classes; endif; ?>">
@@ -24,7 +24,7 @@
 			<?php
         $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 				$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());?>
-			<h4>
+			<h5>
 				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
 					<?php
 						if ($show_post_type):
@@ -34,10 +34,10 @@
 						endif; ?>
 					<?php echo $localized_title; ?>
 				</a>
-			</h4>
+			</h5>
 		<?php else: ?>
 			<p>
-				<h4>
+				<h5>
 					<?php
 						$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
 					 ?>
@@ -52,7 +52,7 @@
 
 							<?php echo $localized_title; ?>
 						</a>
-				</h4>
+				</h5>
 			</p>
 		<?php endif; ?>
 
@@ -72,13 +72,13 @@
 				endif;
 			endif;
 			?>
-			<?php if ($show_excerpt || $show_source_meta): ?>				
+			<?php if ($show_excerpt || $show_source_meta): ?>
 					<?php if ($show_excerpt): ?>
 						<div class="post-excerpt">
-							<?php 
-								$excerpt = odm_excerpt($post); 
+							<?php
+								$excerpt = odm_excerpt($post);
 								if (isset($highlight_words_query) && function_exists('wp_odm_solr_highlight_search_words')):
-									$excerpt = wp_odm_solr_highlight_search_words($highlight_words_query,$excerpt); 									
+									$excerpt = wp_odm_solr_highlight_search_words($highlight_words_query,$excerpt);
 								endif;
 								echo $excerpt; ?>
 						</div>

--- a/inc/templates/post-list-single-2-cols.php
+++ b/inc/templates/post-list-single-2-cols.php
@@ -23,7 +23,7 @@
       <?php
         $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 				$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());?>
-			<h4>
+			<h5>
 				<a class="item-title" href="<?php echo $link; ?>" title="<?php echo $localized_title; ?>">
 					<?php
 						if ($show_post_type):
@@ -33,11 +33,10 @@
 						endif; ?>
 					<?php echo $localized_title; ?>
 				</a>
-			</h4>
+			</h5>
 		<?php else: ?>
 			<p>
-				<h4>
-
+				<h5>
 					<?php
 						$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
 					 ?>
@@ -52,7 +51,7 @@
 
 						<?php echo $localized_title; ?>
 					</a>
-				</h4>
+				</h5>
 			</p>
 		<?php endif; ?>
 
@@ -78,11 +77,11 @@
 				endif; ?>
 				<?php if ($show_excerpt): ?>
 					<div class="post-excerpt">
-						<?php 
-							$excerpt = odm_excerpt($post); 
+						<?php
+							$excerpt = odm_excerpt($post);
 							if (isset($highlight_words_query) && function_exists('wp_odm_solr_highlight_search_words')):
-								$excerpt = wp_odm_solr_highlight_search_words($highlight_words_query,$excerpt); 								
-							endif; 
+								$excerpt = wp_odm_solr_highlight_search_words($highlight_words_query,$excerpt);
+							endif;
 							echo $excerpt;?>
 					</div>
 				<?php endif; ?>

--- a/inc/templates/post-list-single-2-cols.php
+++ b/inc/templates/post-list-single-2-cols.php
@@ -35,24 +35,22 @@
 				</a>
 			</h5>
 		<?php else: ?>
-			<p>
-				<h5>
-					<?php
-						$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
-					 ?>
-					<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
+			<h5>
+				<?php
+					$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
+				 ?>
+				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
 
+				<?php
+					if ($show_post_type):
+						$post_type_name = get_post_type($post->ID); ?>
+						<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
 					<?php
-						if ($show_post_type):
-							$post_type_name = get_post_type($post->ID); ?>
-							<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
-						<?php
-						endif; ?>
+					endif; ?>
 
-						<?php echo $localized_title; ?>
-					</a>
-				</h5>
-			</p>
+					<?php echo $localized_title; ?>
+				</a>
+			</h5>
 		<?php endif; ?>
 
 		<?php

--- a/inc/templates/post-list-single-4-cols.php
+++ b/inc/templates/post-list-single-4-cols.php
@@ -38,24 +38,22 @@
 				</a>
 			</h5>
 		<?php else: ?>
-			<p>
-				<h5>
-					<?php
-						$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
-					 ?>
-					<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
+			<h5>
+				<?php
+					$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
+				 ?>
+				<a class="item-title" href="<?php echo get_permalink($post->ID); ?>" title="<?php echo $localized_title; ?>">
 
+				<?php
+					if ($show_post_type):
+						$post_type_name = get_post_type($post->ID); ?>
+						<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
 					<?php
-						if ($show_post_type):
-							$post_type_name = get_post_type($post->ID); ?>
-							<i class="<?php echo get_post_type_icon_class($post_type_name); ?>"></i>
-						<?php
-						endif; ?>
+					endif; ?>
 
-						<?php echo $localized_title; ?>
-					</a>
-				</h5>
-			</p>
+					<?php echo $localized_title; ?>
+				</a>
+			</h5>
 		<?php endif; ?>
 
 		<?php

--- a/inc/templates/post-list-single-4-cols.php
+++ b/inc/templates/post-list-single-4-cols.php
@@ -23,7 +23,7 @@
       <?php
         $link = isset($post->dataset_link) ? $post->dataset_link : get_permalink($post->ID);
 				$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());?>
-			<h4>
+			<h5>
 				<?php
 					$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
 				 ?>
@@ -36,10 +36,10 @@
 						endif; ?>
 					<?php echo $localized_title; ?>
 				</a>
-			</h4>
+			</h5>
 		<?php else: ?>
 			<p>
-				<h4>
+				<h5>
 					<?php
 						$localized_title = apply_filters('translate_text', $post->post_title, odm_language_manager()->get_current_language());
 					 ?>
@@ -54,7 +54,7 @@
 
 						<?php echo $localized_title; ?>
 					</a>
-				</h4>
+				</h5>
 			</p>
 		<?php endif; ?>
 
@@ -77,11 +77,11 @@
 			<?php if ($show_excerpt || $show_source_meta): ?>
 				<?php if ($show_excerpt): ?>
 					<div class="post-excerpt">
-						<?php 
-							$excerpt = odm_excerpt($post); 
+						<?php
+							$excerpt = odm_excerpt($post);
 							if (isset($highlight_words_query) && function_exists('wp_odm_solr_highlight_search_words')):
-								$excerpt = wp_odm_solr_highlight_search_words($highlight_words_query,$excerpt); 								
-							endif; 
+								$excerpt = wp_odm_solr_highlight_search_words($highlight_words_query,$excerpt);
+							endif;
 							echo $excerpt; ?>
 					</div>
 					<?php if( echo_downloaded_documents()):

--- a/inc/utils/content.php
+++ b/inc/utils/content.php
@@ -170,9 +170,9 @@ function print_category_by_post_type( $category, $post_type ="post", $current_ca
 		$included_posttype = '?post_type='.$post_type;
 	endif;
   if($post_type == "map-layer" && is_page(array("map-explorer", "maps")) ){
-    $cat_name = '<h4><a href="' . $get_category_link. $included_posttype.'">';
+    $cat_name = '<a href="' . $get_category_link. $included_posttype.'">';
     $cat_name .= $category->name;
-    $cat_name .= "</a></h4>";
+    $cat_name .= "</a>";
     $count_layer_items = 0;
     $args_get_post = array(
         'post_type' => $post_type,
@@ -216,7 +216,7 @@ function print_category_by_post_type( $category, $post_type ="post", $current_ca
     } //$query_get_post->have_posts
   }else {
     echo "<span class='nochildimage-".odm_country_manager()->get_current_country().$current_page."'>";
-            echo '<h4><a href="' . get_category_link( $category->cat_ID ) .$included_posttype.'">';
+            echo '<a href="' . get_category_link( $category->cat_ID ) .$included_posttype.'">';
                 if ($current_cat == $category->slug){ // if page of the topic exists
                     echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
                         echo $category->name;
@@ -224,7 +224,7 @@ function print_category_by_post_type( $category, $post_type ="post", $current_ca
                 }else{
                       echo $category->name;
                 }
-            echo "</a></h4>";
+            echo "</a>";
       echo "</span>";
   }
 }
@@ -390,8 +390,8 @@ function echo_post_meta($the_post, $show_elements = array('date','categories','t
   			}
       endif; ?>
       <?php
-			if (in_array('categories',$show_elements) && !empty(get_the_category())): ?>        
-			<?php 
+			if (in_array('categories',$show_elements) && !empty(get_the_category())): ?>
+			<?php
 				$category_list = wp_get_post_categories($post->ID,array('fields' => 'all_with_object_id'));
 				if (isset($max_num_topics) && $max_num_topics > 0):
 					$category_list = array_splice($category_list,0,$max_num_topics);
@@ -402,7 +402,7 @@ function echo_post_meta($the_post, $show_elements = array('date','categories','t
 					<?php
 						foreach ($category_list as $category): ?>
 							<a href="<?php echo get_category_link($category->term_id) ?>"><?php echo $category->name ?></a>
-						<?php 
+						<?php
 							if ($category != end($category_list)):
 								echo " / ";
 							endif;
@@ -412,8 +412,8 @@ function echo_post_meta($the_post, $show_elements = array('date','categories','t
 				endif;
 			endif; ?>
       <?php
-			if (in_array('tags',$show_elements)): ?>				
-					<?php 
+			if (in_array('tags',$show_elements)): ?>
+					<?php
 					$tag_list = get_the_tags();
 					if (isset($max_num_tags) && $max_num_tags > 0):
 						$tag_list = array_splice($tag_list,0,$max_num_tags);
@@ -424,7 +424,7 @@ function echo_post_meta($the_post, $show_elements = array('date','categories','t
 								<?php
 							  foreach($tag_list as $tag): ?>
 							    <a href="<?php echo get_tag_link($tag->term_id) ?>"><?php echo $tag->name ?></a>
-							  <?php 
+							  <?php
 									if ($tag != end($tag_list)):
 										echo " / ";
 									endif;
@@ -432,7 +432,7 @@ function echo_post_meta($the_post, $show_elements = array('date','categories','t
 						</li>
 				<?php
 				 	endif;
-	      endif; ?>			
+	      endif; ?>
 			<?php
 			if (in_array('show_summary_translated_by_odc_team',$show_elements)): ?>
 				<?php echo_post_translated_by_od_team(get_the_ID());

--- a/inc/utils/content.php
+++ b/inc/utils/content.php
@@ -170,9 +170,9 @@ function print_category_by_post_type( $category, $post_type ="post", $current_ca
 		$included_posttype = '?post_type='.$post_type;
 	endif;
   if($post_type == "map-layer" && is_page(array("map-explorer", "maps")) ){
-    $cat_name = '<a href="' . $get_category_link. $included_posttype.'">';
+    $cat_name = '<h4><a href="' . $get_category_link. $included_posttype.'">';
     $cat_name .= $category->name;
-    $cat_name .= "</a>";
+    $cat_name .= "</a></h4>";
     $count_layer_items = 0;
     $args_get_post = array(
         'post_type' => $post_type,
@@ -216,7 +216,7 @@ function print_category_by_post_type( $category, $post_type ="post", $current_ca
     } //$query_get_post->have_posts
   }else {
     echo "<span class='nochildimage-".odm_country_manager()->get_current_country().$current_page."'>";
-            echo '<a href="' . get_category_link( $category->cat_ID ) .$included_posttype.'">';
+            echo '<h4><a href="' . get_category_link( $category->cat_ID ) .$included_posttype.'">';
                 if ($current_cat == $category->slug){ // if page of the topic exists
                     echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
                         echo $category->name;
@@ -224,7 +224,7 @@ function print_category_by_post_type( $category, $post_type ="post", $current_ca
                 }else{
                       echo $category->name;
                 }
-            echo "</a>";
+            echo "</a></h4>";
       echo "</span>";
   }
 }

--- a/inc/widgets/odm-taxonomy-widget.php
+++ b/inc/widgets/odm-taxonomy-widget.php
@@ -49,7 +49,7 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 		echo "<span class='nochildimage-".odm_country_manager()->get_current_country()." ".$current_page."'>";
 		if ($get_post_id){ // if page of the topic exists
 			$hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
-			echo '<a'.$hyperlink_color.' href="' . get_permalink( $get_post_id ) . '">';
+			echo '<h4><a'.$hyperlink_color.' href="' . get_permalink( $get_post_id ) . '">';
 		}else{
 							$hyperlink_color = "";
 					}
@@ -65,7 +65,7 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 			 echo "</strong>";
 		}
 		if ($get_post_id)
-			echo "</a>";
+			echo "</a><h4>";
 		echo "</span>";
 	}
 

--- a/inc/widgets/odm-taxonomy-widget.php
+++ b/inc/widgets/odm-taxonomy-widget.php
@@ -51,8 +51,8 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 			$hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
 			echo '<h4><a'.$hyperlink_color.' href="' . get_permalink( $get_post_id ) . '">';
 		}else{
-							$hyperlink_color = "";
-					}
+			$hyperlink_color = "";
+		}
 		$in_category = in_category( $category->term_id );
 		if ($in_category){
 			 echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
@@ -65,7 +65,7 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 			 echo "</strong>";
 		}
 		if ($get_post_id)
-			echo "</a><h4>";
+			echo "</a></h4>";
 		echo "</span>";
 	}
 
@@ -83,7 +83,7 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 		// add link if contetns categorized by this topic exist
 		if ($category_has_contents):
 			$hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
-			echo '<a'.$hyperlink_color.' href="/category/' . $category->slug . '">';
+			echo '<h4><a'.$hyperlink_color.' href="/category/' . $category->slug . '">';
 		else:
       $hyperlink_color = "";
     endif;
@@ -102,7 +102,7 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 		}
 
 		if ($category_has_contents)
-			echo "</a>";
+			echo "</a></h4>";
 
 		echo "</span>";
 

--- a/inc/widgets/odm-taxonomy-widget.php
+++ b/inc/widgets/odm-taxonomy-widget.php
@@ -48,13 +48,13 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 		}
 		echo "<span class='nochildimage-".odm_country_manager()->get_current_country()." ".$current_page."'>";
 		if ($get_post_id): // if page of the topic exists
-			echo '<h4><a href="' . get_permalink( $get_post_id ) . '">';
+			echo '<h5><a href="' . get_permalink( $get_post_id ) . '">';
 		endif;
 
 		echo $category->name;
 
 		if ($get_post_id):
-			echo "</a></h4>";
+			echo "</a></h5>";
 		endif;
 
 		echo "</span>";
@@ -73,13 +73,13 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 
 		// add link if contetns categorized by this topic exist
 		if ($category_has_contents):
-			echo '<h4><a href="/category/' . $category->slug . '">';
+			echo '<h5><a href="/category/' . $category->slug . '">';
     endif;
 
 		echo $category->name;
 
 		if ($category_has_contents):
-			echo "</a></h4>";
+			echo "</a></h5>";
 		endif;
 
 		echo "</span>";

--- a/inc/widgets/odm-taxonomy-widget.php
+++ b/inc/widgets/odm-taxonomy-widget.php
@@ -47,25 +47,25 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 			}
 		}
 		echo "<span class='nochildimage-".odm_country_manager()->get_current_country()." ".$current_page."'>";
-		if ($get_post_id){ // if page of the topic exists
-			$hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
-			echo '<h4><a'.$hyperlink_color.' href="' . get_permalink( $get_post_id ) . '">';
-		}else{
-			$hyperlink_color = "";
-		}
+		if ($get_post_id): // if page of the topic exists
+			echo '<h4><a class="' . odm_country_manager()->get_current_country() . '-color" href="' . get_permalink( $get_post_id ) . '">';
+		endif;
+
 		$in_category = in_category( $category->term_id );
-		if ($in_category){
-			 echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
-			 $hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
-		}else {
-			$hyperlink_color = "";
-		}
-			echo $category->name;
-		if ($in_category){
+		if ($in_category):
+			echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
+		endif;
+
+		echo $category->name;
+
+		if ($in_category):
 			 echo "</strong>";
-		}
-		if ($get_post_id)
+		endif;
+
+		if ($get_post_id):
 			echo "</a></h4>";
+		endif;
+
 		echo "</span>";
 	}
 
@@ -82,27 +82,23 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 
 		// add link if contetns categorized by this topic exist
 		if ($category_has_contents):
-			$hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
-			echo '<h4><a'.$hyperlink_color.' href="/category/' . $category->slug . '">';
-		else:
-      $hyperlink_color = "";
+			echo '<h4><a class="' . odm_country_manager()->get_current_country() . '-color" href="/category/' . $category->slug . '">';
     endif;
 
 		$in_category = in_category( $category->term_id );
 		if ($in_category):
 			echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
-			$hyperlink_color =  " class='".odm_country_manager()->get_current_country()."-color'";
-		else:
-			$hyperlink_color = "";
 		endif;
+
 		echo $category->name;
 
-		if ($in_category){
-			 echo "</strong>";
-		}
+		if ($in_category):
+			echo "</strong>";
+		endif;
 
-		if ($category_has_contents)
+		if ($category_has_contents):
 			echo "</a></h4>";
+		endif;
 
 		echo "</span>";
 

--- a/inc/widgets/odm-taxonomy-widget.php
+++ b/inc/widgets/odm-taxonomy-widget.php
@@ -48,19 +48,10 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 		}
 		echo "<span class='nochildimage-".odm_country_manager()->get_current_country()." ".$current_page."'>";
 		if ($get_post_id): // if page of the topic exists
-			echo '<h4><a class="' . odm_country_manager()->get_current_country() . '-color" href="' . get_permalink( $get_post_id ) . '">';
-		endif;
-
-		$in_category = in_category( $category->term_id );
-		if ($in_category):
-			echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
+			echo '<h4><a href="' . get_permalink( $get_post_id ) . '">';
 		endif;
 
 		echo $category->name;
-
-		if ($in_category):
-			 echo "</strong>";
-		endif;
 
 		if ($get_post_id):
 			echo "</a></h4>";
@@ -82,19 +73,10 @@ class Odm_Taxonomy_Widget extends WP_Widget {
 
 		// add link if contetns categorized by this topic exist
 		if ($category_has_contents):
-			echo '<h4><a class="' . odm_country_manager()->get_current_country() . '-color" href="/category/' . $category->slug . '">';
+			echo '<h4><a href="/category/' . $category->slug . '">';
     endif;
 
-		$in_category = in_category( $category->term_id );
-		if ($in_category):
-			echo "<strong class='".odm_country_manager()->get_current_country()."-color'>";
-		endif;
-
 		echo $category->name;
-
-		if ($in_category):
-			echo "</strong>";
-		endif;
 
 		if ($category_has_contents):
 			echo "</a></h4>";

--- a/less/_layout.less
+++ b/less/_layout.less
@@ -66,7 +66,6 @@ body{
 
 		.item-title {
       font-family: @title-font !important;
-			font-size: @font-size-h3;
 			display: inline-block;
       color: @white !important;
       position: relative;
@@ -210,23 +209,18 @@ body{
   display: flex;
   clear: both;
 
-  .post-grid-item-caption-bolow {
+  .post-grid-item-caption-below {
     min-height: 200px;
     max-width: 20%;
     height: auto;
     flex:1;
     background: @mekong-dark;
 
-  /*  &:nth-child(4n+1) {
-      clear: left;
-    }*/
-
   	.grid-content-wrapper {
   		padding: 1px 1px 10px 1px;
 
   		.item-title {
         font-family: @title-font  !important;
-  			font-size: @font-size-h3;
   			display: inline-block;
         color: @white !important;
         padding: @xsmall-padd @small-padd;
@@ -234,10 +228,6 @@ body{
 
       .post-grid-item-list {
           padding: 0;
-
-          .item-title {
-			      font-size: @font-size-h4 !important;
-          }
 
           li {
             margin-bottom: 6px;
@@ -299,7 +289,7 @@ body{
     display: table-cell;
     vertical-align: top;
     float: left;
-    
+
     img{
       max-width: 80px;
       max-height: 80px;
@@ -334,10 +324,6 @@ body{
 }
 
 .highlighted{
-
-  .item-title {
-    font-size: @font-size-h2 !important;
-	}
 
   .post-excerpt {
     font-size: @font-size-h3 !important;

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -344,7 +344,7 @@ ul.odm_taxonomy_widget_ul span:hover{
 	}
 }
 
-.summary-item{
+.summary-item a{
 	font-weight: bolder;
 	font-size: @font-size-h4;
 }

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -169,6 +169,7 @@
 		  span.nochildimage-mekong {
 	      display: inline-block;
 	      padding-left: 20px;
+        font-size: @font-size-h5;
 		  }
       span.plusimage-mekong {
         background: url("../../img/expand-mekong.png") no-repeat 0 8px!important;

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -343,3 +343,8 @@ ul.odm_taxonomy_widget_ul span:hover{
 		}
 	}
 }
+
+.summary-item{
+	font-weight: bolder;
+	font-size: @font-size-h4;
+}

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -346,5 +346,5 @@ ul.odm_taxonomy_widget_ul span:hover{
 
 .summary-item a{
 	font-weight: bolder;
-	font-size: @font-size-h5;
+	font-size: @font-size-h4;
 }

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -153,7 +153,7 @@
 		  span.nochildimage-mekong {
 	      display: inline-block;
 	      padding-left: 20px;
-        font-size: @font-size-h6;
+        font-size: @font-size-h5;
 		  }
       span.plusimage-mekong {
         background: url("../../img/expand-mekong.png") no-repeat 0 8px!important;

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -185,7 +185,7 @@
 	}
 
 	.summary-item a{
-		font-weight: bolder;
+		font-weight: normal;
 		font-size: @font-size-h5;
 	}
 

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -124,16 +124,9 @@
 	  color: @mekong-dark;
 	}
 
-  .item-title {
-    font-size: @base-font-size !important;
-  }
 	li a {
-    font-family: @title-font;
-    text-decoration: none;
-    color: @mekong-text-color;
 
 		&:hover {
-		  text-decoration:none;
       color: @mekong-dark;
 		}
 

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -39,15 +39,6 @@
 		}
 	}
 
-	.odm-summary ol li a {
-		text-decoration: none;
-		color: #333;
-		&:hover {
-			color: #4683d2; /*6393D2, 2774da;*/
-			text-decoration: underline;
-		}
-	}
-
 	.wpckan_dataset_list > ul > li {
 		margin: 0 0 10px !important;
 		padding: 0 !important;
@@ -193,6 +184,11 @@
 	  list-style-position: inside;
 	}
 
+	.summary-item a{
+		font-weight: bolder;
+		font-size: @font-size-h4;
+	}
+
 	li {
 		list-style: none !important;
 		list-style-type: none !important;
@@ -335,9 +331,4 @@ ul.odm_taxonomy_widget_ul span:hover{
 
 		}
 	}
-}
-
-.summary-item a{
-	font-weight: bolder;
-	font-size: @font-size-h4;
 }

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -346,5 +346,5 @@ ul.odm_taxonomy_widget_ul span:hover{
 
 .summary-item a{
 	font-weight: bolder;
-	font-size: @font-size-h4;
+	font-size: @font-size-h5;
 }

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -169,7 +169,7 @@
 		  span.nochildimage-mekong {
 	      display: inline-block;
 	      padding-left: 20px;
-        font-size: @font-size-h5;
+        font-size: @font-size-h6;
 		  }
       span.plusimage-mekong {
         background: url("../../img/expand-mekong.png") no-repeat 0 8px!important;

--- a/less/_sidebar-widget.less
+++ b/less/_sidebar-widget.less
@@ -186,7 +186,7 @@
 
 	.summary-item a{
 		font-weight: bolder;
-		font-size: @font-size-h4;
+		font-size: @font-size-h5;
 	}
 
 	li {

--- a/less/_typography.less
+++ b/less/_typography.less
@@ -1,7 +1,6 @@
 @import url(_open_sans.less);
 @import url(_droid_sans.less);
 
-
 body {
 	font-family: @primary-font;
 	color: @primary-color;
@@ -88,8 +87,6 @@ a strong:hover{
 	color: @mekong-dark;
 }
 
-
-
 td, li {
 	font-family: @primary-font;
 	font-size: @base-font-size;
@@ -97,7 +94,6 @@ td, li {
 }
 
 .excerpt { font-weight: light; }
-
 
 h2 em {
   font-weight: normal;

--- a/less/_typography.less
+++ b/less/_typography.less
@@ -64,6 +64,7 @@ p {
 	color: @primary-color;
 	font-size: @base-font-size;
 	font-weight: normal;
+	line-height: @paragraph-line-height;
 }
 
 a, a:visited{

--- a/less/_typography.less
+++ b/less/_typography.less
@@ -17,22 +17,47 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
 	font-size: @font-size-h1;
 	line-height: @title-line-height;
+
+	a{
+		font-size: @font-size-h1;
+		text-decoration: none;
+	}
 }
 h2 {
 	font-size: @font-size-h2;
 	line-height: @title-line-height;
+
+	a{
+		font-size: @font-size-h2;
+		text-decoration: none;
+	}
 }
 h3 {
 	font-size: @font-size-h3;
 	line-height: @subtitle-line-height;
+
+	a{
+		font-size: @font-size-h3;
+		text-decoration: none;
+	}
 }
 h4 {
 	font-size: @font-size-h4;
 	line-height: @subtitle-line-height;
+
+	a{
+		font-size: @font-size-h4;
+		text-decoration: none;
+	}
 }
 h5 {
 	font-size: @font-size-h5;
 	line-height: @subtitle-line-height;
+
+	a{
+		font-size: @font-size-h5;
+		text-decoration: none;
+	}
 }
 
 p {
@@ -73,11 +98,9 @@ td, li {
 
 .excerpt { font-weight: light; }
 
-h5 a {
-    text-decoration: none;
-}
+
 h2 em {
-    font-weight: normal;
+  font-weight: normal;
 }
 
 sup{

--- a/less/_typography.less
+++ b/less/_typography.less
@@ -55,7 +55,6 @@ h5 {
 
 	a{
 		font-size: @font-size-h5;
-		font-weight: normal;
 		text-decoration: none;
 	}
 }

--- a/less/_typography.less
+++ b/less/_typography.less
@@ -55,7 +55,16 @@ h5 {
 
 	a{
 		font-size: @font-size-h5;
+		font-weight: normal;
 		text-decoration: none;
+	}
+}
+
+#sidebar{
+	h5 {
+		a{
+			font-weight: normal;
+		}
 	}
 }
 

--- a/less/_variables.less
+++ b/less/_variables.less
@@ -17,6 +17,7 @@
 
 @title-line-height: 32px;
 @subtitle-line-height: 24px;
+@paragraph-line-height: 21px;
 
 /* ========== Layout ============ */
 

--- a/less/_wpckan.less
+++ b/less/_wpckan.less
@@ -10,12 +10,6 @@
     margin-bottom: @small-padd;
   }
 
-  .wpckan_dataset_title a, .wpckan_dataset_title_translated a{
-    font-family: @title-font;
-    font-size: @font-size-h5;
-    text-decoration: none;
-  }
-
 	ul {
 
 		margin-left: 0px !important;
@@ -29,6 +23,7 @@
 }
 
 .wpckan_dataset_detail{
+
   h1, .wpckan_dataset_title{
       margin-bottom: 0;
   }

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -98,6 +98,7 @@ html#map-embed #embed-header {
       display: inline-block;
       background: url("../../img/no-child-kh.png") no-repeat 0 8px!important;
       padding-left: 20px;
+      font-size: @font-size-h5;
     }
   }
 }

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -99,7 +99,7 @@ html#map-embed #embed-header {
       display: inline-block;
       background: url("../../img/no-child-kh.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h5;
+      font-size: @font-size-h6;
     }
   }
 }

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -3,6 +3,7 @@
 
 @import url(https://fonts.googleapis.com/css?family=Suwannaphum);
 @import "_country-mixin.less";
+@import "_variables.less";
 
 @cambodia-text-color: #00A600;
 @cambodia-bright: #97D320;

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -99,7 +99,6 @@ html#map-embed #embed-header {
       display: inline-block;
       background: url("../../img/no-child-kh.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h6;
     }
   }
 }

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -10,10 +10,6 @@
 @cambodia-bgcolor: #06323D;
 @cambodia-menu-color: #12414e;
 
-body{
-  font: 14px/24px "Open Sans","Helvetica","Arial",sans-serif;
-}
-
 .km{
   font-family: 'Suwannaphum', "Open Sans","Helvetica","Arial",sans-serif;
 }
@@ -91,7 +87,7 @@ html#map-embed #embed-header {
 		span.nochildimage-cambodia {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h6;
+			font-size: @font-size-h4;
 		}
 
     span.plusimage-cambodia {

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -85,20 +85,23 @@ html#map-embed #embed-header {
   }
 
   ul li {
+
+		span.plusimage-cambodia,
+		span.minusimage-cambodia,
+		span.nochildimage-cambodia {
+			display: inline-block;
+			padding-left: 20px;
+			font-size: @font-size-h6;
+		}
+
     span.plusimage-cambodia {
-      display: inline-block;
       background: url("../../img/expand-kh.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.minusimage-cambodia {
-      display: inline-block;
       background: url("../../img/collapse-kh.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.nochildimage-cambodia {
-      display: inline-block;
       background: url("../../img/no-child-kh.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
   }
 }

--- a/less/cambodia.less
+++ b/less/cambodia.less
@@ -87,7 +87,7 @@ html#map-embed #embed-header {
 		span.nochildimage-cambodia {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h4;
+			font-size: @font-size-h5;
 		}
 
     span.plusimage-cambodia {

--- a/less/laos.less
+++ b/less/laos.less
@@ -60,7 +60,7 @@ html#map-embed #embed-header {
 		span.nochildimage-laos {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h4;
+			font-size: @font-size-h5;
 		}
 
     span.plusimage-laos {

--- a/less/laos.less
+++ b/less/laos.less
@@ -2,6 +2,7 @@
 // to be converted to dist/css/laos.css
 
 @import "_country-mixin.less";
+@import "_variables.less";
 
 /* Color */
 @laos-text-color: #D61E2A;

--- a/less/laos.less
+++ b/less/laos.less
@@ -60,7 +60,7 @@ html#map-embed #embed-header {
 		span.nochildimage-laos {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h6;
+			font-size: @font-size-h4;
 		}
 
     span.plusimage-laos {

--- a/less/laos.less
+++ b/less/laos.less
@@ -54,20 +54,23 @@ html#map-embed #embed-header {
   }
 
   ul li {
+
+		span.plusimage-laos,
+		span.minusimage-laos,
+		span.nochildimage-laos {
+			display: inline-block;
+			padding-left: 20px;
+			font-size: @font-size-h6;
+		}
+
     span.plusimage-laos {
-      display: inline-block;
       background: url("../../img/expand-lo.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.minusimage-laos {
-      display: inline-block;
       background: url("../../img/collapse-lo.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.nochildimage-laos {
-      display: inline-block;
       background: url("../../img/no-child-lo.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
   }
 }

--- a/less/laos.less
+++ b/less/laos.less
@@ -68,7 +68,7 @@ html#map-embed #embed-header {
       display: inline-block;
       background: url("../../img/no-child-lo.png") no-repeat 0 8px!important;
       padding-left: 20px;
-			font-size: @font-size-h5;
+			font-size: @font-size-h6;
     }
   }
 }

--- a/less/laos.less
+++ b/less/laos.less
@@ -68,7 +68,6 @@ html#map-embed #embed-header {
       display: inline-block;
       background: url("../../img/no-child-lo.png") no-repeat 0 8px!important;
       padding-left: 20px;
-			font-size: @font-size-h6;
     }
   }
 }

--- a/less/laos.less
+++ b/less/laos.less
@@ -8,7 +8,7 @@
 @laos-bright: #D61E2A;
 @laos-bgcolor: #3b2226;
 @laos-menu-color: #583A43;
- 
+
 #laos-bgcolor, .laos-bgcolor{
     background: @laos-bright !important
 }
@@ -67,6 +67,7 @@ html#map-embed #embed-header {
       display: inline-block;
       background: url("../../img/no-child-lo.png") no-repeat 0 8px!important;
       padding-left: 20px;
+			font-size: @font-size-h5;
     }
   }
 }

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -2,6 +2,7 @@
 // to be converted to dist/css/myanmar.css
 
 @import "_country-mixin.less";
+@import "_variables.less";
 
 @import url('https://mmwebfonts.comquas.com/fonts/?font=myanmar3');
 

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -93,7 +93,7 @@ h1, h2, h3, h4, h5, h6, p, a, li, td, th, div, input {
 		span.nochildimage-myanmar {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h6;
+			font-size: @font-size-h4;
 		}
 
     span.plusimage-myanmar {

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -93,7 +93,7 @@ h1, h2, h3, h4, h5, h6, p, a, li, td, th, div, input {
 		span.nochildimage-myanmar {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h4;
+			font-size: @font-size-h5;
 		}
 
     span.plusimage-myanmar {

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -101,7 +101,7 @@ h1, h2, h3, h4, h5, h6, p, a, li, td, th, div, input {
       display: inline-block;
       background: url("../../img/no-child-my.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h5;
+      font-size: @font-size-h6;
     }
   }
 }

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -100,6 +100,7 @@ h1, h2, h3, h4, h5, h6, p, a, li, td, th, div, input {
       display: inline-block;
       background: url("../../img/no-child-my.png") no-repeat 0 8px!important;
       padding-left: 20px;
+      font-size: @font-size-h5;
     }
   }
 }

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -101,7 +101,6 @@ h1, h2, h3, h4, h5, h6, p, a, li, td, th, div, input {
       display: inline-block;
       background: url("../../img/no-child-my.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h6;
     }
   }
 }

--- a/less/myanmar.less
+++ b/less/myanmar.less
@@ -87,20 +87,23 @@ h1, h2, h3, h4, h5, h6, p, a, li, td, th, div, input {
   }
 
   ul li {
+
+		span.plusimage-myanmar,
+		span.minusimage-myanmar,
+		span.nochildimage-myanmar {
+			display: inline-block;
+			padding-left: 20px;
+			font-size: @font-size-h6;
+		}
+
     span.plusimage-myanmar {
-      display: inline-block;
       background: url("../../img/expand-my.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.minusimage-myanmar {
-      display: inline-block;
       background: url("../../img/collapse-my.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.nochildimage-myanmar {
-      display: inline-block;
       background: url("../../img/no-child-my.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
   }
 }

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -74,7 +74,7 @@
       display: inline-block;
       background: url("../../img/no-child-th.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h5;
+      font-size: @font-size-h6;
     }
   }
 }

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -60,20 +60,23 @@
   }
 
   ul li {
+
+		span.plusimage-thailand,
+		span.minusimage-thailand,
+		span.nochildimage-thailand {
+			display: inline-block;
+			padding-left: 20px;
+			font-size: @font-size-h6;
+		}
+
     span.plusimage-thailand {
-      display: inline-block;
       background: url("../../img/expand-th.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.minusimage-thailand {
-      display: inline-block;
       background: url("../../img/collapse-th.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.nochildimage-thailand {
-      display: inline-block;
       background: url("../../img/no-child-th.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
   }
 }

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -8,7 +8,7 @@
 @thailand-bright: #F7904D;
 @thailand-bgcolor: #64161d;
 @thailand-menu-color: #772028;
- 
+
 #thailand-bgcolor, .thailand-bgcolor{
     background: @thailand-bright !important
 }
@@ -73,6 +73,7 @@
       display: inline-block;
       background: url("../../img/no-child-th.png") no-repeat 0 8px!important;
       padding-left: 20px;
+      font-size: @font-size-h5;
     }
   }
 }

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -66,7 +66,7 @@
 		span.nochildimage-thailand {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h4;
+			font-size: @font-size-h5;
 		}
 
     span.plusimage-thailand {

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -2,6 +2,7 @@
 // to be converted to dist/css/thailand.css
 
 @import "_country-mixin.less";
+@import "_variables.less";
 
 /* Color */
 @thailand-text-color: #E25D13;

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -74,7 +74,6 @@
       display: inline-block;
       background: url("../../img/no-child-th.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h6;
     }
   }
 }

--- a/less/thailand.less
+++ b/less/thailand.less
@@ -66,7 +66,7 @@
 		span.nochildimage-thailand {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h6;
+			font-size: @font-size-h4;
 		}
 
     span.plusimage-thailand {

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -73,6 +73,7 @@
       display: inline-block;
       background: url("../../img/no-child-vn.png") no-repeat 0 8px!important;
       padding-left: 20px;
+      font-size: @font-size-h5;
     }
   }
 }

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -66,7 +66,7 @@
 		span.nochildimage-vietnam {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h4;
+			font-size: @font-size-h5;
 		}
 
     span.plusimage-vietnam {

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -2,6 +2,7 @@
 // to be converted to dist/css/vietnam.css
 
 @import "_country-mixin.less";
+@import "_variables.less";
 
 /* Color */
 @vietnam-text-color: #A89B04;

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -74,7 +74,7 @@
       display: inline-block;
       background: url("../../img/no-child-vn.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h5;
+      font-size: @font-size-h6;
     }
   }
 }

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -66,7 +66,7 @@
 		span.nochildimage-vietnam {
 			display: inline-block;
 			padding-left: 20px;
-			font-size: @font-size-h6;
+			font-size: @font-size-h4;
 		}
 
     span.plusimage-vietnam {

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -74,7 +74,6 @@
       display: inline-block;
       background: url("../../img/no-child-vn.png") no-repeat 0 8px!important;
       padding-left: 20px;
-      font-size: @font-size-h6;
     }
   }
 }

--- a/less/vietnam.less
+++ b/less/vietnam.less
@@ -60,20 +60,23 @@
   }
 
   ul li {
+
+		span.plusimage-vietnam,
+		span.minusimage-vietnam,
+		span.nochildimage-vietnam {
+			display: inline-block;
+			padding-left: 20px;
+			font-size: @font-size-h6;
+		}
+
     span.plusimage-vietnam {
-      display: inline-block;
       background: url("../../img/expand-vn.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.minusimage-vietnam {
-      display: inline-block;
       background: url("../../img/collapse-vn.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
     span.nochildimage-vietnam {
-      display: inline-block;
       background: url("../../img/no-child-vn.png") no-repeat 0 8px!important;
-      padding-left: 20px;
     }
   }
 }

--- a/lib/js/summary.js
+++ b/lib/js/summary.js
@@ -23,15 +23,15 @@
 			hItems.each(function() {
 				if($(this).is('.summary-item')) {
 					var item = $('<li/>').addClass($(this).attr('id') + ' ' + $(this).attr('class'));
-                    var clone = $(this).find('a').clone();
-                    clone.text($(this).find('a').attr('title'));
+          var clone = $(this).find('a').clone();
+          clone.text($(this).find('a').attr('title'));
 					item.append(clone);
 					container.find('ol').append(item);
 				}
 			});
 		}else{ // odm
 			$('#content .odm-summary').parent('li').hide();
-		} 
+		}
 	}
 
 })(jQuery);

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Open Development Mekong
 Author URI: http://github.com/OpenDevelopmentMekong
 Description: Open Development Mekong's wordpress theme. Based on JEO child theme
 Template: jeo
-Version: 2.2.55
+Version: 2.2.56
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */


### PR DESCRIPTION
@Huyeng THis PR contains many changes and might be difficult to review. However I would kindly like to ask you to review it by checking out this branch on PP or on your local machine.

I have been cleaning the CSS and PHP to harmonize the fonts as much as possible, keeping a consistent style-guide for the links on sidebar widgets but also on the instances of ODM Custom posts widget which we use across the sites.

The main thing to consider is that now, all the links exposed by these widgets are ```<h5></h5>``` headings. I have also removed many CSS properties which were basically overriding this, thus making the CSS/LESS files less maintainable.

See some screenshots:

![screenshot from 2017-06-12 18-48-53](https://user-images.githubusercontent.com/384894/27045182-6b5108d0-4fa0-11e7-8350-742f631bf5aa.png)
![screenshot from 2017-06-12 18-49-02](https://user-images.githubusercontent.com/384894/27045178-6b4cdcce-4fa0-11e7-9c85-e882812681cf.png)
![screenshot from 2017-06-12 18-49-11](https://user-images.githubusercontent.com/384894/27045181-6b4ec4da-4fa0-11e7-8fdb-d0e483660544.png)
![screenshot from 2017-06-12 18-49-21](https://user-images.githubusercontent.com/384894/27045177-6b4cb2d0-4fa0-11e7-8daa-8878c191242a.png)
![screenshot from 2017-06-12 18-49-33](https://user-images.githubusercontent.com/384894/27045179-6b4e1d96-4fa0-11e7-9c93-8a655803f381.png)
![screenshot from 2017-06-12 18-49-51](https://user-images.githubusercontent.com/384894/27045180-6b4e7f5c-4fa0-11e7-86ad-a847174e916d.png)
