### PR TITLE
Fixes #1217

### DIFF
--- a/archive-announcement.php
+++ b/archive-announcement.php
@@ -43,11 +43,10 @@ $date_to_show = isset($options['single_page_date']) ? $options['single_page_date
 				odm_get_template('post-list-single-2-cols',array(
 					"post" => get_post(),
 					"show_meta" => true,
-					"meta_fields" => array("date","categories","tags", "sources"),
+					"meta_fields" => array("date","categories","tags", "sources","summary_translated"),
 					"show_source_meta" => true,
 					"show_thumbnail" => true,
 					"show_excerpt" => true,
-					"show_summary_translated_by_odc_team" => true,
 					"header_tag" => true,
 					"order" => $date_to_show
 			),true);

--- a/archive-news-article.php
+++ b/archive-news-article.php
@@ -53,11 +53,10 @@ $date_to_show = isset($options['single_page_date']) ? $options['single_page_date
 				odm_get_template('post-list-single-2-cols',array(
 					"post" => get_post(),
 					"show_meta" => true,
-					"meta_fields" => array("date","categories","tags", "sources"),
+					"meta_fields" => array("date","categories","tags", "sources", "summary_translated"),
 					"show_source_meta" => true,
 					"show_thumbnail" => true,
 					"show_excerpt" => true,
-					"show_summary_translated_by_odc_team" => true,
 					"header_tag" => true,
 					"order" => $date_to_show
 			),true);

--- a/archive-site-update.php
+++ b/archive-site-update.php
@@ -28,11 +28,10 @@ $date_to_show = isset($options['single_page_date']) ? $options['single_page_date
 				odm_get_template('post-list-single-2-cols',array(
 					"post" => get_post(),
 					"show_meta" => true,
-					"meta_fields" => array("date","categories","tags"),
+					"meta_fields" => array("date","categories","tags","summary_translated"),
 					"show_source_meta" => true,
 					"show_thumbnail" => true,
 					"show_excerpt" => true,
-					"show_summary_translated_by_odc_team" => true,
 					"header_tag" => true,
 					"order" => $date_to_show
 			),true);

--- a/inc/templates/category-page-default.php
+++ b/inc/templates/category-page-default.php
@@ -62,11 +62,10 @@ foreach($selected_posttype as $pt) {
 	                odm_get_template('post-list-single-2-cols',array(
 										"post" => get_post(),
 				  					"show_meta" => true,
-				  					"meta_fields" => array("date","categories","tags", "sources"),
+				  					"meta_fields" => array("date","categories","tags", "sources","summary_translated"),
 				  					"show_source_meta" => true,
 				  					"show_thumbnail" => true,
 				  					"show_excerpt" => true,
-				  					"show_summary_translated_by_odc_team" => true,
 				  					"header_tag" => true,
 				  					"order" => $date_to_show,
 				  					"index" => $index

--- a/inc/templates/category-page-latest.php
+++ b/inc/templates/category-page-latest.php
@@ -65,11 +65,10 @@ $term = $wp_query->queried_object;
                     odm_get_template('post-highlighted-single-1-cols',array(
                         "post" => $post,
                         "show_meta" => true,
-												"meta_fields" => array("date","categories","tags","sources"),
+												"meta_fields" => array("date","categories","tags","sources","summary_translated"),
                         "show_source_meta" => true,
                         "show_thumbnail" => true,
                         "show_excerpt" => true,
-                        "show_summary_translated_by_odc_team" => true,
                         "header_tag" => true,
 												"show_more_link" => true
                     ),true);
@@ -86,11 +85,10 @@ $term = $wp_query->queried_object;
                     odm_get_template('post-highlighted-single-1-cols',array(
                         "post" => $post,
                         "show_meta" => true,
-												"meta_fields" => array("date","categories","tags","sources"),
+												"meta_fields" => array("date","categories","tags","sources","summary_translated"),
                         "show_source_meta" => true,
                         "show_thumbnail" => true,
                         "show_excerpt" => true,
-                        "show_summary_translated_by_odc_team" => true,
                         "header_tag" => false,
 												"show_more_link" => true
                     ),true);

--- a/inc/templates/post-blog-layout-2-cols.php
+++ b/inc/templates/post-blog-layout-2-cols.php
@@ -11,7 +11,6 @@
 	$highlight_words_query = isset($params["highlight_words_query"]) ? $params["highlight_words_query"] : null;
 	$solr_search_result = isset($params["solr_search_result"]) ? $params["solr_search_result"] : null;
 	$show_post_type = isset($params["show_post_type"]) ? $params["show_post_type"] : false;
-	$show_summary_translated_by_odc_team = isset($params["show_summary_translated_by_odc_team"]) ? $params["show_summary_translated_by_odc_team"] : false;
 	$header_tag = isset($params["header_tag"]) ? $params["header_tag"] : false;
 	$order = isset($params["order"]) ? $params["order"] : "metadata_created";
 	$extra_classes = isset($params["extra_classes"]) ? $params["extra_classes"] : null;

--- a/inc/templates/post-highlighted-single-1-cols.php
+++ b/inc/templates/post-highlighted-single-1-cols.php
@@ -11,7 +11,6 @@
 	$show_excerpt = isset($params["show_excerpt"]) ? $params["show_excerpt"] : false;
 	$show_source_meta = isset($params["show_source_meta"]) ? $params["show_source_meta"] : false;
 	$show_post_type = isset($params["show_post_type"]) ? $params["show_post_type"] : false;
-	$show_summary_translated_by_odc_team = isset($params["show_summary_translated_by_odc_team"]) ? $params["show_summary_translated_by_odc_team"] : false;
 	$header_tag = isset($params["header_tag"]) ? $params["header_tag"] : false;
 	$order = isset($params["order"]) ? $params["order"] : "metadata_created";
 ?>
@@ -58,7 +57,7 @@
 					endif;
 
 					echo_downloaded_documents();
-						
+
 				endif;
 					?>
 		</section>

--- a/inc/templates/post-list-single-1-cols.php
+++ b/inc/templates/post-list-single-1-cols.php
@@ -11,7 +11,6 @@
 	$show_excerpt = isset($params["show_excerpt"]) ? $params["show_excerpt"] : false;
 	$show_source_meta = isset($params["show_source_meta"]) ? $params["show_source_meta"] : false;
 	$show_post_type = isset($params["show_post_type"]) ? $params["show_post_type"] : false;
-	$show_summary_translated_by_odc_team = isset($params["show_summary_translated_by_odc_team"]) ? $params["show_summary_translated_by_odc_team"] : false;
 	$header_tag = isset($params["header_tag"]) ? $params["header_tag"] : false;
 	$order = isset($params["order"]) ? $params["order"] : "metadata_created";
 	$extra_classes = isset($params["extra_classes"]) ? $params["extra_classes"] : null;
@@ -89,7 +88,7 @@
 				endif;
 
 				echo_downloaded_documents();
-				
+
 			endif;
 				?>
 			</section>

--- a/inc/templates/post-list-single-2-cols.php
+++ b/inc/templates/post-list-single-2-cols.php
@@ -11,7 +11,6 @@
 	$highlight_words_query = isset($params["highlight_words_query"]) ? $params["highlight_words_query"] : null;
 	$solr_search_result = isset($params["solr_search_result"]) ? $params["solr_search_result"] : null;
 	$show_post_type = isset($params["show_post_type"]) ? $params["show_post_type"] : false;
-	$show_summary_translated_by_odc_team = isset($params["show_summary_translated_by_odc_team"]) ? $params["show_summary_translated_by_odc_team"] : false;
 	$header_tag = isset($params["header_tag"]) ? $params["header_tag"] : false;
 	$order = isset($params["order"]) ? $params["order"] : "metadata_created";
 	$extra_classes = isset($params["extra_classes"]) ? $params["extra_classes"] : null;
@@ -86,7 +85,7 @@
 					endif;
 
 					echo_downloaded_documents();
-					
+
 				endif;
 				?>
 		</section>

--- a/inc/templates/post-list-single-4-cols.php
+++ b/inc/templates/post-list-single-4-cols.php
@@ -11,7 +11,6 @@
 	$highlight_words_query = isset($params["highlight_words_query"]) ? $params["highlight_words_query"] : null;
 	$solr_search_result = isset($params["solr_search_result"]) ? $params["solr_search_result"] : null;
 	$show_post_type = isset($params["show_post_type"]) ? $params["show_post_type"] : false;
-	$show_summary_translated_by_odc_team = isset($params["show_summary_translated_by_odc_team"]) ? $params["show_summary_translated_by_odc_team"] : false;
 	$header_tag = isset($params["header_tag"]) ? $params["header_tag"] : false;
 	$order = isset($params["order"]) ? $params["order"] : "metadata_created";
 	$extra_classes = isset($params["extra_classes"]) ? $params["extra_classes"] : null;
@@ -88,7 +87,7 @@
 					endif;
 
 					echo_downloaded_documents();
-					
+
 				endif;
 				?>
 		</section>

--- a/inc/utils/content.php
+++ b/inc/utils/content.php
@@ -535,8 +535,8 @@ function echo_post_meta($the_post, $show_elements = array('date','categories','t
 				 	endif;
 	      endif; ?>
 			<?php
-			if (in_array('show_summary_translated_by_odc_team',$show_elements)): ?>
-				<?php echo_post_translated_by_od_team(get_the_ID());
+			if (in_array('summary_translated',$show_elements)): ?>
+				<?php echo_post_translated_by_country_team(get_the_ID());
 			endif; ?>
 		</ul>
 	</div>
@@ -607,7 +607,7 @@ function shorten_string_words($string, $limit = 40, $current_lang = "en"){
 
 }
 
-function echo_post_translated_by_od_team($postID, $current_lang = "en", $taxonomy ="language") {
+function echo_post_translated_by_country_team($postID, $current_lang = "en", $taxonomy ="language") {
  	    $site_language = strtolower(odm_language_manager()->get_the_language_by_language_code($current_lang)); //english
  			$translated_term =  $site_language."-translated";
 			$team_name = "OD". ucfirst(substr(odm_country_manager()->get_current_country(), 0, 1));

--- a/loop.php
+++ b/loop.php
@@ -16,11 +16,10 @@
 		  				odm_get_template('post-'.$template.'-2-cols',array(
 		  					"post" => get_post(),
 		  					"show_meta" => true,
-		  					"meta_fields" => array("date","categories","tags","sources"),
+		  					"meta_fields" => array("date","categories","tags","sources","summary_translated"),
 		  					"show_source_meta" => true,
 		  					"show_thumbnail" => true,
 		  					"show_excerpt" => true,
-		  					"show_summary_translated_by_odc_team" => true,
 		  					"header_tag" => true,
 		  					"order" => $date_to_show,
 		  					"index" => $index
@@ -42,37 +41,3 @@
   		</div>
   	</div>
   </section>
-
-<?php /*if (have_posts()) : ?>
-	<section class="posts-section row">
-		<div class="container">
-			<div class="eleven columns">
-					<?php while (have_posts()) : the_post(); ?>
-						<?php odm_get_template('post-list-single-1-cols',array(
-	  					"post" => get_post(),
-	  					"show_meta" => true,
-							"show_excerpt" => true,
-							"show_author_and_url_source" => true,
-							"show_summary_translated_by_odc_team" => true
-	  			),true);
-					?>
-					<?php endwhile; ?>
-			</div>
-
-			<div class="four columns offset-by-one">
-				<aside id="sidebar">
-					<ul class="widgets">
-						<li class="widget share-widget">
-							<?php odm_get_template('social-share',array(),true); ?>
-						</li>
-
-						<?php dynamic_sidebar(); ?>
-						<li id="odm_taxonomy_widget" class="widget widget_odm_taxonomy_widget">
-							<?php list_category_by_post_type(); ?>
-						</li>
-					</ul>
-				</aside>
-			</div>
-		</div>
-	</section>
-<?php endif; */ ?>

--- a/page-blog.php
+++ b/page-blog.php
@@ -39,7 +39,7 @@ Template Name: Blog Page
   					"show_source_meta" => true,
   					"show_thumbnail" => true,
   					"show_excerpt" => true,
-  					"show_summary_translated_by_odc_team" => true,
+  					"summary_translated" => true,
   					"header_tag" => true,
   					"order" => $date_to_show,
   					"index" => $index

--- a/single.php
+++ b/single.php
@@ -10,7 +10,7 @@
     <section class="container section-title main-title">
         <div class="eleven columns post-title">
           <header class="row">
-						<?php odm_title($post,array('date','categories','tags','sources'),$date_to_show); ?>        
+						<?php odm_title($post,array('date','categories','tags','sources','summary_translated'),$date_to_show); ?>
 					</header>
 					<section class="content section-content">
             <?php

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Open Development Mekong
 Author URI: http://github.com/OpenDevelopmentMekong
 Description: Open Development Mekong's wordpress theme. Based on JEO child theme
 Template: jeo
-Version: 2.4.16
+Version: 2.4.17
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */


### PR DESCRIPTION
@Huyeng @gimmemochi This PR fixes issue #1217 and makes sure that the "Translated by X Team" message is shown for those News articles, announcements, and site updates which editors have accordingly marked ( Language taxonomy) See screenshots:

![screenshot from 2017-11-02 11-29-48](https://user-images.githubusercontent.com/384894/32321387-41b6d162-bfc1-11e7-93b3-8a95fdfb6472.png)
![screenshot from 2017-11-02 11-30-24](https://user-images.githubusercontent.com/384894/32321389-42fe398e-bfc1-11e7-8e80-2473f7014e6c.png)

@Huyeng you want to review this before I deploy it?
