### PR TITLE
Fixes #1248

### DIFF
--- a/less/_posts.less
+++ b/less/_posts.less
@@ -284,13 +284,6 @@
 
 	.post-content {
 
-		.tableauPlaceholder {
-			width: 100%;
-			border: 1px solid #ddd;
-			padding: 10px;
-			background: #f4f4f4 none repeat scroll 0;
-		}
-
 		iframe {
 			max-width:100%;
 		}

--- a/less/_posts.less
+++ b/less/_posts.less
@@ -283,12 +283,16 @@
 	}
 
 	.post-content {
-		iframe {
-			max-width:100%;
-			margin-bottom: 24px;
+
+		.tableauPlaceholder {
+			width: 100%;
 			border: 1px solid #ddd;
 			padding: 10px;
 			background: #f4f4f4 none repeat scroll 0;
+		}
+
+		iframe {
+			max-width:100%;
 		}
 		p {
 			sub {

--- a/less/_posts.less
+++ b/less/_posts.less
@@ -285,6 +285,10 @@
 	.post-content {
 		iframe {
 			max-width:100%;
+			margin-bottom: 24px;
+			border: 1px solid #ddd;
+			padding: 10px;
+			background: #f4f4f4 none repeat scroll 0;
 		}
 		p {
 			sub {

--- a/less/opendev.less
+++ b/less/opendev.less
@@ -53,7 +53,11 @@ table {
 }
 
 .tableauPlaceholder{
-    margin: 5px auto 20px;
+  margin: 5px auto 10px;
+	width: 100%;
+	border: 1px solid #ddd;
+	padding: 10px;
+	background: #f4f4f4 none repeat scroll 0;
 }
  .table-of-contents sup{
      display: none;

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Open Development Mekong
 Author URI: http://github.com/OpenDevelopmentMekong
 Description: Open Development Mekong's wordpress theme. Based on JEO child theme
 Template: jeo
-Version: 2.4.23
+Version: 2.4.24
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */


### PR DESCRIPTION
This PR introduces changes on the CSS styling of the wp-odm_theme in order to **automatically** add a grey box around ALL tableau visualizations as shown in the screenshot below:

![screenshot from 2018-01-29 11-37-34](https://user-images.githubusercontent.com/384894/35506249-f834bd70-04e8-11e8-91cb-31faf1c2d4ab.png)

These changes are currently deployed on PP for testing.

@prustar adding the source as part of the caption is not possible without manually changing the html embedded code which can be a potential error source. We would need to figure out a way to integrate those captions better on tableau visualizations

